### PR TITLE
Add method to retrieve last revision for app name

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiManager.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/SiddhiManager.java
@@ -237,6 +237,16 @@ public class SiddhiManager {
         }
     }
 
+    /**
+     * Method to retrieve last revision for siddhi app by providing the name.
+     *
+     * @param siddhiAppName Name of the required Siddhi app
+     * @return revision
+     */
+    public String getLastRevision(String siddhiAppName) {
+        return siddhiContext.getPersistenceStore().getLastRevision(siddhiAppName);
+    }
+
     public void setIncrementalPersistenceStore(IncrementalPersistenceStore incrementalPersistenceStore) {
         this.siddhiContext.setIncrementalPersistenceStore(incrementalPersistenceStore);
     }


### PR DESCRIPTION
## Purpose
To enable siddhi manager to access last revision time for siddhi app

## Goals
to make available last persisted revision for a siddhi app


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
