### PR TITLE
Fix for wso2/carbon-analytics#1503

### DIFF
--- a/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/annotation/Element.java
+++ b/modules/siddhi-query-api/src/main/java/org/wso2/siddhi/query/api/annotation/Element.java
@@ -46,9 +46,9 @@ public class Element implements SiddhiElement {
     @Override
     public String toString() {
         if (key != null) {
-            return key + " = '" + value + "'";
+            return key + " = \"" + value + "\"";
         } else {
-            return "'" + value + "'";
+            return "\"" + value + "\"";
         }
     }
 


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/carbon-analytics/issues/1503 together with https://github.com/wso2/carbon-analytics/pull/1504.

## Goals
- `toString()` method is used when building the Siddhi app from the design view.
- It is better to use double quotes to wrap annotation elements in `toString()` method so that the values can have single quotes. 
- This also fixes https://github.com/wso2/carbon-analytics/issues/1503.

## Approach
Using double quotes instead of single quotes to wrap element value. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/wso2/carbon-analytics/pull/1504

## Migrations (if applicable)
N/A