### PR TITLE
Remove javax.annotations added while code generation from swagger

### DIFF
--- a/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/ApiException.java
+++ b/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/ApiException.java
@@ -16,8 +16,6 @@
 
 package org.wso2.siddhi.service.api;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen", date =
-        "2017-03-15T08:56:59.657Z")
 public class ApiException extends Exception {
     private int code;
 

--- a/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/ApiOriginFilter.java
+++ b/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/ApiOriginFilter.java
@@ -24,8 +24,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen", date =
-        "2017-03-15T08:56:59.657Z")
 public class ApiOriginFilter implements javax.servlet.Filter {
     public void doFilter(ServletRequest request, ServletResponse response,
                          FilterChain chain) throws IOException, ServletException {

--- a/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/ApiResponseMessage.java
+++ b/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/ApiResponseMessage.java
@@ -16,11 +16,6 @@
 
 package org.wso2.siddhi.service.api;
 
-import javax.xml.bind.annotation.XmlTransient;
-
-@javax.xml.bind.annotation.XmlRootElement
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen", date =
-        "2017-03-15T08:56:59.657Z")
 public class ApiResponseMessage {
     public static final int ERROR = 1;
     public static final int WARNING = 2;
@@ -60,7 +55,6 @@ public class ApiResponseMessage {
         this.message = message;
     }
 
-    @XmlTransient
     public int getCode() {
         return code;
     }

--- a/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/NotFoundException.java
+++ b/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/NotFoundException.java
@@ -16,8 +16,6 @@
 
 package org.wso2.siddhi.service.api;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen", date =
-        "2017-03-15T08:56:59.657Z")
 public class NotFoundException extends ApiException {
     private int code;
 

--- a/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/SiddhiApi.java
+++ b/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/SiddhiApi.java
@@ -31,8 +31,6 @@ import javax.ws.rs.core.Response;
 @Path("/siddhi")
 
 @io.swagger.annotations.Api(description = "The siddhi API")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen", date =
-        "2017-03-15T08:56:59.657Z")
 public class SiddhiApi {
     private final SiddhiApiService delegate = SiddhiApiServiceFactory.getSiddhiApi();
 

--- a/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/SiddhiApiService.java
+++ b/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/SiddhiApiService.java
@@ -19,8 +19,6 @@ package org.wso2.siddhi.service.api;
 
 import javax.ws.rs.core.Response;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen", date =
-        "2017-03-15T08:56:59.657Z")
 public abstract class SiddhiApiService {
 
     public abstract Response siddhiArtifactDeployPost(String body) throws NotFoundException;

--- a/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/StringUtil.java
+++ b/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/api/StringUtil.java
@@ -16,8 +16,6 @@
 
 package org.wso2.siddhi.service.api;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen", date =
-        "2017-03-15T08:56:59.657Z")
 public class StringUtil {
     /**
      * Check if the given array contains the given value (with case-insensitive comparison).

--- a/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/model/Error.java
+++ b/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/model/Error.java
@@ -24,8 +24,6 @@ import java.util.Objects;
 /**
  * Error
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen", date =
-        "2017-03-15T08:56:59.657Z")
 public class Error {
     @JsonProperty("code")
     private Integer code = null;

--- a/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/model/Success.java
+++ b/modules/siddhi-service/src/gen/java/org/wso2/siddhi/service/model/Success.java
@@ -26,8 +26,6 @@ import java.util.Objects;
 /**
  * Success
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen", date =
-        "2017-03-15T08:56:59.657Z")
 public class Success {
     @JsonProperty("code")
     private Integer code = null;

--- a/modules/siddhi-service/src/main/java/org/wso2/siddhi/service/impl/SiddhiApiServiceImpl.java
+++ b/modules/siddhi-service/src/main/java/org/wso2/siddhi/service/impl/SiddhiApiServiceImpl.java
@@ -39,9 +39,6 @@ import javax.ws.rs.core.Response;
 /**
  * Siddhi Service Implementataion Class
  */
-
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaMSF4JServerCodegen",
-        date = "2017-03-15T08:56:59.657Z")
 public class SiddhiApiServiceImpl extends SiddhiApiService {
 
     private Log log = LogFactory.getLog(SiddhiApiServiceImpl.class);


### PR DESCRIPTION
## Purpose
> Since javax package has been removed from JDK 11

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes