### PR TITLE
Supporting non standard IDs using ``

### DIFF
--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/streamfunction/AttributeStreamFunction.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/streamfunction/AttributeStreamFunction.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.siddhi.core.query.streamfunction;
+
+import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
+import org.wso2.siddhi.core.executor.ConstantExpressionExecutor;
+import org.wso2.siddhi.core.executor.ExpressionExecutor;
+import org.wso2.siddhi.core.query.processor.stream.function.StreamFunctionProcessor;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+import org.wso2.siddhi.query.api.definition.AbstractDefinition;
+import org.wso2.siddhi.query.api.definition.Attribute;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class AttributeStreamFunction extends StreamFunctionProcessor {
+    @Override
+    protected Object[] process(Object[] data) {
+        return new Object[]{"test"};
+    }
+
+    @Override
+    protected Object[] process(Object data) {
+        return new Object[]{"test"};
+    }
+
+    @Override
+    protected List<Attribute> init(AbstractDefinition inputDefinition,
+                                   ExpressionExecutor[] attributeExpressionExecutors,
+                                   ConfigReader configReader, SiddhiAppContext siddhiAppContext) {
+        if (attributeExpressionExecutors.length != 1) {
+            throw new SiddhiAppCreationException("Only one attribute is expected but found " +
+                    attributeExpressionExecutors.length);
+        }
+        if (!(attributeExpressionExecutors[0] instanceof ConstantExpressionExecutor)) {
+            throw new SiddhiAppCreationException("Attribute is expected to be constant, but its not!");
+        }
+        List<Attribute> newAttributes = new ArrayList<>();
+        newAttributes.add(
+                new Attribute(((ConstantExpressionExecutor) attributeExpressionExecutors[0]).getValue().toString(),
+                        inputDefinition.getAttributeList().get(0).getType()));
+        return newAttributes;
+    }
+
+    @Override
+    public void start() {
+
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+    @Override
+    public Map<String, Object> currentState() {
+        return null;
+    }
+
+    @Override
+    public void restoreState(Map<String, Object> state) {
+
+    }
+}

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/streamfunction/StreamFunctionTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/query/streamfunction/StreamFunctionTestCase.java
@@ -176,8 +176,9 @@ public class StreamFunctionTestCase {
                 EventPrinter.print(timestamp, inEvents, removeEvents);
                 if (inEvents != null) {
                     inEventCount = inEventCount + inEvents.length;
-//                    AssertJUnit.assertEquals(12, Math.round((Double) inEvents[0].getData(0)));
-//                    AssertJUnit.assertEquals(5, Math.round((Double) inEvents[0].getData(1)));
+                    AssertJUnit.assertEquals(22.6, inEvents[0].getData(0));
+                    AssertJUnit.assertEquals(13.0,inEvents[0].getData(1));
+                    AssertJUnit.assertEquals("test",inEvents[0].getData(2));
 
                 }
                 eventArrived = true;

--- a/modules/siddhi-query-compiler/src/main/antlr4/org/wso2/siddhi/query/compiler/SiddhiQL.g4
+++ b/modules/siddhi-query-compiler/src/main/antlr4/org/wso2/siddhi/query/compiler/SiddhiQL.g4
@@ -847,7 +847,7 @@ AGGREGATION: A G G R E G A T I O N;
 AGGREGATE: A G G R E G A T E;
 PER:      P E R;
 
-ID_QUOTES : '`'[a-zA-Z_] [a-zA-Z_0-9]*'`' {setText(getText().substring(1, getText().length()-1));};
+ID_QUOTES : '`'(.*?)'`' {setText(getText().substring(1, getText().length()-1));};
 
 ID : [a-zA-Z_] [a-zA-Z_0-9]* ;
 


### PR DESCRIPTION
This allows us to define and use streams as
```
define stream `$InputStream` (`56$2theta` double, rho double);

```