### PR TITLE
Add findbugs suppression to support JAVA 11

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -196,7 +196,7 @@
     </Match>
     <!--Suppression added to support for Java 11-->
     <Match>
-        <Package name="~org\.wso2\.siddhi\.core\.event\.stream\.holder\.SnapshotableStreamEventQueue"/>
+        <Class name="~org\.wso2\.siddhi\.core\.event\.stream\.holder\.SnapshotableStreamEventQueue"/>
         <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED"/>
     </Match>
 

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -194,6 +194,11 @@
         <Package name="~org\.wso2\.siddhi\.core\.util\.snapshot\.*"/>
         <Bug pattern="AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION"/>
     </Match>
+    <!--Suppression added to support for Java 11-->
+    <Match>
+        <Package name="~org\.wso2\.siddhi\.core\.event\.stream\.holder\.SnapshotableStreamEventQueue"/>
+        <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED"/>
+    </Match>
 
     <!--other-->
     <Match>


### PR DESCRIPTION
## Purpose
> When building with Java 11, we encounter a SE_TRANSIENT_FIELD_NOT_RESTORED findbug in class SnapshotableStreamEventQueue. We do not encounter the same while building with Java 8. 

## Goals
> Support Siddhi building with both Java 8 and Java 11.

## Approach
> Add a findbugs suppression in findbugs-exclude.xml for SE_TRANSIENT_FIELD_NOT_RESTORED in SnapshotableStreamEventQueue class.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
>  N/A

## Marketing
> N/A

## Automation tests
 - N/A 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> OracleJDK 11, OracleJDK 8, OpenJDK 11
 
## Learning
> N/A