### PR TITLE
Fix SHARD_ID not added as one of the primarykey coloumn

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/AggregationParser.java
@@ -177,6 +177,7 @@ public class AggregationParser {
                     throw new SiddhiAppCreationException("Configuration 'shardId' not provided for @partitionbyid " +
                             "annotation");
                 }
+                enablePartioning = true;
             }
 
             boolean isLatestEventAdded = populateIncomingAggregatorsAndExecutors(


### PR DESCRIPTION
## Purpose
SHARD_ID of the distributed aggregation tables are not added as one of the primary key, only when distributed aggregation is enabled by the 'partitionById' siddhi property

## Goals
Fix https://github.com/siddhi-io/siddhi/issues/1073

## Approach
Update local variable properly

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
