### PR TITLE
Create indexed CompareCollectionExpression when left and right parts …

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/CollectionExpressionParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/CollectionExpressionParser.java
@@ -257,26 +257,33 @@ public class CollectionExpressionParser {
                         return new CompareCollectionExpression((Compare) expression, CollectionExpression.CollectionScope.PARTIAL_PRIMARY_KEY_RESULT_SET,
                                 rightCollectionExpression, operator, leftCollectionExpression);
                 }
-            } else if((leftCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.INDEXED_ATTRIBUTE ||
+            } else if ((leftCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.INDEXED_ATTRIBUTE ||
                        leftCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.PRIMARY_KEY_ATTRIBUTE ||
                        leftCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.PARTIAL_PRIMARY_KEY_ATTRIBUTE)
                       && (rightCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.INDEXED_ATTRIBUTE ||
                           rightCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.PRIMARY_KEY_ATTRIBUTE ||
                           rightCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.PARTIAL_PRIMARY_KEY_ATTRIBUTE)) {
                 // comparing indexed table field with stream attributes
-                switch (leftCollectionExpression.getCollectionScope()) {
-                    case INDEXED_ATTRIBUTE:
-                        return new CompareCollectionExpression((Compare) expression, CollectionExpression.CollectionScope.INDEXED_RESULT_SET,
-                            leftCollectionExpression, ((Compare) expression).getOperator(),
-                            rightCollectionExpression);
-                    case PRIMARY_KEY_ATTRIBUTE:
-                        return new CompareCollectionExpression((Compare) expression, CollectionExpression.CollectionScope.PRIMARY_KEY_RESULT_SET,
-                            leftCollectionExpression, ((Compare) expression).getOperator(),
-                            rightCollectionExpression);
-                    case PARTIAL_PRIMARY_KEY_ATTRIBUTE:
-                        return new CompareCollectionExpression((Compare) expression, CollectionExpression.CollectionScope.PARTIAL_PRIMARY_KEY_RESULT_SET,
-                            leftCollectionExpression, ((Compare) expression).getOperator(),
-                            rightCollectionExpression);
+                Compare.Operator operator = ((Compare) expression).getOperator();
+                if (operator == Compare.Operator.EQUAL) {
+                    // for equality an indexed result set can be used for collection expression (better performance)
+                    switch (leftCollectionExpression.getCollectionScope()) {
+                        case INDEXED_ATTRIBUTE:
+                            return new CompareCollectionExpression((Compare) expression, CollectionExpression.CollectionScope.INDEXED_RESULT_SET,
+                                leftCollectionExpression, ((Compare) expression).getOperator(),
+                                rightCollectionExpression);
+                        case PRIMARY_KEY_ATTRIBUTE:
+                            return new CompareCollectionExpression((Compare) expression, CollectionExpression.CollectionScope.PRIMARY_KEY_RESULT_SET,
+                                leftCollectionExpression, ((Compare) expression).getOperator(),
+                                rightCollectionExpression);
+                        case PARTIAL_PRIMARY_KEY_ATTRIBUTE:
+                            return new CompareCollectionExpression((Compare) expression, CollectionExpression.CollectionScope.PARTIAL_PRIMARY_KEY_RESULT_SET,
+                                leftCollectionExpression, ((Compare) expression).getOperator(),
+                                rightCollectionExpression);
+                    }
+                } else {
+                    // for other operators (e.g. LESS_THAN, GREATER_THAN) a BasicCollectionExpression (with exhaustive scope) is still used
+                    return new BasicCollectionExpression(expression, CollectionExpression.CollectionScope.EXHAUSTIVE);
                 }
             } else {
                 //comparing non indexed table with stream attributes or another table attribute

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/CollectionExpressionParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/CollectionExpressionParser.java
@@ -257,6 +257,27 @@ public class CollectionExpressionParser {
                         return new CompareCollectionExpression((Compare) expression, CollectionExpression.CollectionScope.PARTIAL_PRIMARY_KEY_RESULT_SET,
                                 rightCollectionExpression, operator, leftCollectionExpression);
                 }
+            } else if((leftCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.INDEXED_ATTRIBUTE ||
+                       leftCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.PRIMARY_KEY_ATTRIBUTE ||
+                       leftCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.PARTIAL_PRIMARY_KEY_ATTRIBUTE)
+                      && (rightCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.INDEXED_ATTRIBUTE ||
+                          rightCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.PRIMARY_KEY_ATTRIBUTE ||
+                          rightCollectionExpression.getCollectionScope() == CollectionExpression.CollectionScope.PARTIAL_PRIMARY_KEY_ATTRIBUTE)) {
+                // comparing indexed table field with stream attributes
+                switch (leftCollectionExpression.getCollectionScope()) {
+                    case INDEXED_ATTRIBUTE:
+                        return new CompareCollectionExpression((Compare) expression, CollectionExpression.CollectionScope.INDEXED_RESULT_SET,
+                            leftCollectionExpression, ((Compare) expression).getOperator(),
+                            rightCollectionExpression);
+                    case PRIMARY_KEY_ATTRIBUTE:
+                        return new CompareCollectionExpression((Compare) expression, CollectionExpression.CollectionScope.PRIMARY_KEY_RESULT_SET,
+                            leftCollectionExpression, ((Compare) expression).getOperator(),
+                            rightCollectionExpression);
+                    case PARTIAL_PRIMARY_KEY_ATTRIBUTE:
+                        return new CompareCollectionExpression((Compare) expression, CollectionExpression.CollectionScope.PARTIAL_PRIMARY_KEY_RESULT_SET,
+                            leftCollectionExpression, ((Compare) expression).getOperator(),
+                            rightCollectionExpression);
+                }
             } else {
                 //comparing non indexed table with stream attributes or another table attribute
                 return new BasicCollectionExpression(expression, CollectionExpression.CollectionScope.EXHAUSTIVE);


### PR DESCRIPTION
…are indexed attributes

## Purpose
When using an indexed in-memory table, and updating records in it, the performance decreases as the table size increases.
The problem is related to the creation of the CompareCollectionExpression which is used by the update operation on the in-memory table.
The collection executor which is created by parsing the collection expression has an EXHAUSTIVE scope instead of an INDEXED_RESULT_SET scope. And thus, any ‘find’ operation, iterates over all elements of the table.

## Goals
Fix #1088

## Approach
All details are in Issue #1088 

## Release note
Use indexed CompareCollectionExpression when left and right parts are indexed attributes

## Documentation
N/A

## Automation tests
N/A

## Security checks
N/A
 
