### PR TITLE
Remove junit usages from test cases

### DIFF
--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -1,4 +1,4 @@
-# API Docs - v5.0.0-SNAPSHOT
+# API Docs - v5.0.0-m4
 
 ## Core
 

--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -1,4 +1,4 @@
-# API Docs - v5.0.0-m4
+# API Docs - v5.0.0-SNAPSHOT
 
 ## Core
 

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/function/InstanceOfFunctionTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/function/InstanceOfFunctionTestCase.java
@@ -354,7 +354,7 @@ public class InstanceOfFunctionTestCase {
         inputHandler.send(new Object[]{19900813115534L, false, 601, "temperature", 90.34344, 20.44345, 2.3f, 20.44345});
         inputHandler.send(new Object[]{1990, false, 602, "temperature", 90.34344, 20.44345, 2.3f, 20.44345});
         Thread.sleep(100);
-        junit.framework.Assert.assertEquals(2, count);
+        org.testng.Assert.assertEquals(2, count);
         AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
 

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/function/MaximumFunctionExtensionTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/function/MaximumFunctionExtensionTestCase.java
@@ -402,7 +402,7 @@ public class MaximumFunctionExtensionTestCase {
                             AssertJUnit.assertEquals(40.0f, event.getData(0));
                             break;
                         default:
-                            org.junit.Assert.fail();
+                            org.testng.Assert.fail();
                     }
                 }
             }
@@ -463,7 +463,7 @@ public class MaximumFunctionExtensionTestCase {
                             AssertJUnit.assertEquals(3812L, event.getData(0));
                             break;
                         default:
-                            org.junit.Assert.fail();
+                            org.testng.Assert.fail();
                     }
                 }
             }

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/function/MinimumFunctionExtensionTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/function/MinimumFunctionExtensionTestCase.java
@@ -342,7 +342,7 @@ public class MinimumFunctionExtensionTestCase {
                             AssertJUnit.assertEquals(37.75f, event.getData(0));
                             break;
                         default:
-                            org.junit.Assert.fail();
+                            org.testng.Assert.fail();
                     }
                 }
             }
@@ -403,7 +403,7 @@ public class MinimumFunctionExtensionTestCase {
                             AssertJUnit.assertEquals(40L, event.getData(0));
                             break;
                         default:
-                            org.junit.Assert.fail();
+                            org.testng.Assert.fail();
                     }
                 }
             }


### PR DESCRIPTION
## Purpose
> This PR will remove the Junit usages from the test cases and avoid failures when updating the testng dependency. 