### PR TITLE
[Inc. Aggregations] Clone executors for out of order event smoothing

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
@@ -187,13 +187,15 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
         if (isProcessingOnExternalTime) {
             int durationIndex = incrementalDurations.indexOf(perValue);
             List<ExpressionExecutor> expressionExecutors = aggregateProcessingExecutorsList.get(durationIndex);
+            List<ExpressionExecutor> clonedExecutors = expressionExecutors.stream().map(expressionExecutor ->
+                    expressionExecutor.cloneExecutor("")).collect(Collectors.toList());
             GroupByKeyGenerator groupByKeyGenerator = groupbyKeyGeneratorList.get(durationIndex);
 
             ExpressionExecutor shouldUpdateExpressionExecutorCloneExt =
                     (shouldUpdateExpressionExecutor == null) ? null :
                             shouldUpdateExpressionExecutor.cloneExecutor(null);
             IncrementalExternalTimestampDataAggregator incrementalExternalTimestampDataAggregator =
-                    new IncrementalExternalTimestampDataAggregator(expressionExecutors, groupByKeyGenerator,
+                    new IncrementalExternalTimestampDataAggregator(clonedExecutors, groupByKeyGenerator,
                             tableMetaStreamEvent, siddhiAppContext, shouldUpdateExpressionExecutorCloneExt);
             processedEvents = incrementalExternalTimestampDataAggregator
                     .aggregateData(complexEventChunkToHoldWithinMatches);


### PR DESCRIPTION
## Purpose
Fix, query results from event time stamp based aggregations intermittently being doubled. This is because of using the same executors to do the final calculations.
This can only happen when the executors have not been refreshed(aggregation time expired) when doing the final calculations to smooth out the out of order events.

Solve intermittent test case failures, Fixes https://github.com/siddhi-io/siddhi/issues/1110 and fixes https://github.com/siddhi-io/siddhi/issues/1081.

## Goals
Fix the aggregation values getting doubled when querying in the aggregations (based on external timestamp)

## Approach
Clone expression executors used for aggregations before calculating the out of order records

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes