### PR TITLE
Fix continuous metrics logs printed in editor mode

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/config/SiddhiAppContext.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/config/SiddhiAppContext.java
@@ -72,7 +72,7 @@ public class SiddhiAppContext {
         this.eternalReferencedHolders = Collections.synchronizedList(new LinkedList<>());
         this.scriptFunctionMap = new HashMap<String, Script>();
         this.schedulerList = new ArrayList<Scheduler>();
-        this.rootMetricsLevel = Level.BASIC;
+        this.rootMetricsLevel = Level.OFF;
     }
 
     public SiddhiContext getSiddhiContext() {


### PR DESCRIPTION
## Purpose
> $subject

## Goals
> Make metrics to be disabled in the siddhi app context initialization

## Approach
> Make metrics level to OFF as it was initially done https://github.com/siddhi-io/siddhi/blob/v4.4.9/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/config/SiddhiAppContext.java#L50

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 
