### PR TITLE
Fix incorrect parsing of join compile condition

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/CollectionExpressionParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/CollectionExpressionParser.java
@@ -826,7 +826,7 @@ public class CollectionExpressionParser {
             CollectionExpression leftCollectionExpression = ((AndCollectionExpression)
                     collectionExpression).getLeftCollectionExpression();
             CollectionExpression rightCollectionExpression = ((AndCollectionExpression)
-                    collectionExpression).getLeftCollectionExpression();
+                    collectionExpression).getRightCollectionExpression();
             Map<String, ExpressionExecutor> expressionExecutors = buildMultiPrimaryKeyExpressionExecutors(
                     leftCollectionExpression, matchingMetaInfoHolder, variableExpressionExecutors, tableMap,
                     processingMode, outputExpectsExpiredEvents, siddhiQueryContext);


### PR DESCRIPTION
## Purpose
$subject. Fixes https://github.com/siddhi-io/siddhi/issues/1186, In memory Event table primary key lookups throws NPE 

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes