### PR TITLE
 Add support to expose service information for deployment

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/ServiceDeploymentInfo.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/ServiceDeploymentInfo.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.stream;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Service related information to the deployment
+ */
+public class ServiceDeploymentInfo {
+
+    private ServiceProtocol serviceProtocol = ServiceProtocol.TCP;
+    private boolean secured = false;
+    private int port;
+    private Map<String, String> deploymentProperties = new HashMap<>();
+
+    /**
+     * Service related information to the deployment
+     *
+     * @param serviceProtocol the protocol used by the service
+     * @param port            the port of the service
+     * @param secured         is the service protocol secured
+     */
+    public ServiceDeploymentInfo(ServiceProtocol serviceProtocol, int port, boolean secured) {
+        this.serviceProtocol = serviceProtocol;
+        this.port = port;
+        this.secured = secured;
+    }
+
+    /**
+     * Service related information to the deployment
+     *
+     * @param secured is the service protocol secured
+     * @param port    the port of the service
+     */
+    public ServiceDeploymentInfo(int port, boolean secured) {
+        this.port = port;
+        this.secured = secured;
+    }
+
+    public ServiceProtocol getServiceProtocol() {
+        return serviceProtocol;
+    }
+
+    public void setServiceProtocol(ServiceProtocol serviceProtocol) {
+        this.serviceProtocol = serviceProtocol;
+    }
+
+    public boolean isSecured() {
+        return secured;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public void setSecured(boolean secured) {
+        this.secured = secured;
+    }
+
+    public Map<String, String> getDeploymentProperties() {
+        return deploymentProperties;
+    }
+
+    public void addDeploymentProperties(Map<String, String> deploymentProperties) {
+        for (Map.Entry<String, String> entry : deploymentProperties.entrySet()) {
+            this.deploymentProperties.putIfAbsent(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Service protocols
+     */
+    public enum ServiceProtocol {
+        TCP, UDP, SCTP,
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/InMemorySink.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/InMemorySink.java
@@ -24,6 +24,7 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiAppContext;
 import io.siddhi.core.exception.ConnectionUnavailableException;
+import io.siddhi.core.stream.ServiceDeploymentInfo;
 import io.siddhi.core.util.config.ConfigReader;
 import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
@@ -62,6 +63,11 @@ public class InMemorySink extends Sink<State> {
     @Override
     public Class[] getSupportedInputEventClasses() {
         return new Class[]{Object.class};
+    }
+
+    @Override
+    protected ServiceDeploymentInfo exposedServiceDeploymentInfo() {
+        return null;
     }
 
     @Override

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/LogSink.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/LogSink.java
@@ -24,6 +24,7 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiAppContext;
 import io.siddhi.core.exception.ConnectionUnavailableException;
+import io.siddhi.core.stream.ServiceDeploymentInfo;
 import io.siddhi.core.util.config.ConfigReader;
 import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
@@ -100,6 +101,11 @@ public class LogSink extends Sink {
     @Override
     public Class[] getSupportedInputEventClasses() {
         return new Class[]{Object.class};
+    }
+
+    @Override
+    protected ServiceDeploymentInfo exposedServiceDeploymentInfo() {
+        return null;
     }
 
     @Override

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/Sink.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/Sink.java
@@ -204,12 +204,12 @@ public abstract class Sink<S extends State> implements SinkListener {
     /**
      * Sending events via output transport
      *
-     * @param payload          payload of the event
-     * @param transportOptions one of the event constructing the payload
-     * @param state            current state of the sink
+     * @param payload        payload of the event
+     * @param dynamicOptions of the event constructing the payload
+     * @param state          current state of the sink
      * @throws ConnectionUnavailableException throw when connections are unavailable.
      */
-    public abstract void publish(Object payload, DynamicOptions transportOptions, S state)
+    public abstract void publish(Object payload, DynamicOptions dynamicOptions, S state)
             throws ConnectionUnavailableException;
 
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/distributed/DistributedTransport.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/distributed/DistributedTransport.java
@@ -34,7 +34,9 @@ import io.siddhi.query.api.annotation.Element;
 import io.siddhi.query.api.definition.StreamDefinition;
 import org.apache.log4j.Logger;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This is the base class for Distributed transports. All distributed transport types must inherit from this class
@@ -59,8 +61,7 @@ public abstract class DistributedTransport extends Sink {
      */
     @Override
     protected StateFactory<State> init(StreamDefinition outputStreamDefinition, OptionHolder optionHolder,
-                                       ConfigReader sinkConfigReader, SiddhiAppContext
-                                siddhiAppContext) {
+                                       ConfigReader sinkConfigReader, SiddhiAppContext siddhiAppContext) {
         this.streamDefinition = outputStreamDefinition;
         this.sinkOptionHolder = optionHolder;
         this.siddhiAppContext = siddhiAppContext;
@@ -70,35 +71,40 @@ public abstract class DistributedTransport extends Sink {
     /**
      * This is method contains the additional parameters which require to initialize distributed transport
      *
-     * @param streamDefinition         Definition of the stream this sink instance is publishing to
-     * @param type                     Type of the transport that (e.g., TCP, JMS)
-     * @param transportOptionHolder    Option holder for carrying options for the transport
-     * @param sinkConfigReader         This hold the {@link Sink} extensions configuration reader for the sink
-     * @param sinkMapper               Hold the mapper that's used in this sink
-     * @param mapType                  Type of the mapper
-     * @param mapOptionHolder          Options of the mapper
-     * @param sinkHandler              Sink handler to do optional processing
-     * @param payloadElementList       The template list of the payload messages
-     * @param mapperConfigReader       This hold the {@link Sink} extensions configuration reader for the mapper
-     * @param siddhiAppContext         The siddhi app context
-     * @param destinationOptionHolders List of option holders containing the options mentioned in @destination
-     * @param sinkAnnotation           The annotation of the Sink
-     * @param strategy                 Publishing strategy to be used by the distributed transport
-     * @param supportedDynamicOptions  List of supported dynamic options
+     * @param streamDefinition                Definition of the stream this sink instance is publishing to
+     * @param type                            Type of the transport that (e.g., TCP, JMS)
+     * @param transportOptionHolder           Option holder for carrying options for the transport
+     * @param sinkConfigReader                This hold the {@link Sink} extensions configuration reader for the sink
+     * @param sinkMapper                      Hold the mapper that's used in this sink
+     * @param mapType                         Type of the mapper
+     * @param mapOptionHolder                 Options of the mapper
+     * @param sinkHandler                     Sink handler to do optional processing
+     * @param payloadElementList              The template list of the payload messages
+     * @param mapperConfigReader              This hold the {@link Sink} extensions configuration reader for the mapper
+     * @param siddhiAppContext                The siddhi app context
+     * @param destinationOptionHolders        List of option holders containing the options mentioned in @destination
+     * @param sinkAnnotation                  The annotation of the Sink
+     * @param strategy                        Publishing strategy to be used by the distributed transport
+     * @param supportedDynamicOptions         List of supported dynamic options
+     * @param deploymentProperties
+     * @param destinationDeploymentProperties
      */
     public void init(StreamDefinition streamDefinition, String type, OptionHolder transportOptionHolder,
                      ConfigReader sinkConfigReader,
                      SinkMapper sinkMapper, String mapType, OptionHolder mapOptionHolder, SinkHandler sinkHandler,
                      List<Element> payloadElementList, ConfigReader mapperConfigReader,
                      SiddhiAppContext siddhiAppContext, List<OptionHolder> destinationOptionHolders,
-                     Annotation sinkAnnotation, DistributionStrategy strategy, String[] supportedDynamicOptions) {
+                     Annotation sinkAnnotation, DistributionStrategy strategy, String[] supportedDynamicOptions,
+                     Map<String, String> deploymentProperties,
+                     List<Map<String, String>> destinationDeploymentProperties) {
         this.type = type;
         this.strategy = strategy;
         this.supportedDynamicOptions = supportedDynamicOptions;
         init(streamDefinition, type, transportOptionHolder, sinkConfigReader, sinkMapper, mapType, mapOptionHolder,
-                sinkHandler, payloadElementList, mapperConfigReader, siddhiAppContext);
-        initTransport(sinkOptionHolder, destinationOptionHolders, sinkAnnotation, sinkConfigReader, strategy, type,
+                sinkHandler, payloadElementList, mapperConfigReader, new HashMap<>(),
                 siddhiAppContext);
+        initTransport(sinkOptionHolder, destinationOptionHolders, deploymentProperties,
+                destinationDeploymentProperties, sinkAnnotation, sinkConfigReader, strategy, type, siddhiAppContext);
     }
 
     @Override
@@ -153,6 +159,8 @@ public abstract class DistributedTransport extends Sink {
 
 
     public abstract void initTransport(OptionHolder sinkOptionHolder, List<OptionHolder> destinationOptionHolders,
+                                       Map<String, String> deploymentProperties,
+                                       List<Map<String, String>> destinationDeploymentProperties,
                                        Annotation sinkAnnotation, ConfigReader sinkConfigReader,
                                        DistributionStrategy strategy, String type, SiddhiAppContext siddhiAppContext);
 

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/MultiClientDistributedSinkTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/MultiClientDistributedSinkTestCase.java
@@ -21,15 +21,18 @@ package io.siddhi.core.transport;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
+import io.siddhi.core.stream.ServiceDeploymentInfo;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.config.InMemoryConfigManager;
 import io.siddhi.core.util.transport.InMemoryBroker;
 import org.apache.log4j.Logger;
+import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -92,6 +95,9 @@ public class MultiClientDistributedSinkTestCase {
 
         SiddhiManager siddhiManager = new SiddhiManager();
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        List<ServiceDeploymentInfo> serviceDeploymentInfos = siddhiAppRuntime.getSinks().
+                iterator().next().get(0).getServiceDeploymentInfoList();
+        Assert.assertEquals(serviceDeploymentInfos.size(), 0);
         InputHandler stockStream = siddhiAppRuntime.getInputHandler("FooStream");
 
         siddhiAppRuntime.start();
@@ -579,5 +585,92 @@ public class MultiClientDistributedSinkTestCase {
             InMemoryBroker.unsubscribe(subscriptionWSO2);
             InMemoryBroker.unsubscribe(subscriptionIBM);
         }
+    }
+
+    @Test
+    public void multiClientRoundRobinWithDep() throws InterruptedException {
+        log.info("Test inMemorySink And EventMapping With SiddhiQL Dynamic Params");
+
+        InMemoryBroker.Subscriber subscriptionWSO2 = new InMemoryBroker.Subscriber() {
+            @Override
+            public void onMessage(Object msg) {
+                topic1Count.incrementAndGet();
+            }
+
+            @Override
+            public String getTopic() {
+                return "topic1";
+            }
+        };
+
+        InMemoryBroker.Subscriber subscriptionIBM = new InMemoryBroker.Subscriber() {
+            @Override
+            public void onMessage(Object msg) {
+                topic2Count.incrementAndGet();
+            }
+
+            @Override
+            public String getTopic() {
+                return "topic2";
+            }
+        };
+
+        //subscribe to "inMemory" broker per topic
+        InMemoryBroker.subscribe(subscriptionWSO2);
+        InMemoryBroker.subscribe(subscriptionIBM);
+
+        String streams = "" +
+                "@app:name('TestSiddhiApp')" +
+                "define stream FooStream (symbol string, price float, volume long); " +
+                "@sink(type='testDepInMemory', dep:foo='bar', @map(type='passThrough'), " +
+                "   @distribution(strategy='roundRobin', " +
+                "       @destination(topic = 'topic1', dep:foo1='bar1'), " +
+                "       @destination(topic = 'topic2', dep:foo2='bar2'))) " +
+                "define stream BarStream (symbol string, price float, volume long); ";
+
+        String query = "" +
+                "from FooStream " +
+                "select * " +
+                "insert into BarStream; ";
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        List<ServiceDeploymentInfo> serviceDeploymentInfos = siddhiAppRuntime.getSinks().
+                iterator().next().get(0).getServiceDeploymentInfoList();
+        Assert.assertEquals(serviceDeploymentInfos.size(), 2);
+        for (int i = 0; i < serviceDeploymentInfos.size(); i++) {
+            ServiceDeploymentInfo serviceDeploymentInfo = serviceDeploymentInfos.get(i);
+            Assert.assertNotNull(serviceDeploymentInfo);
+            Assert.assertTrue(serviceDeploymentInfo.isSecured());
+            Assert.assertTrue(serviceDeploymentInfo.getServiceProtocol() ==
+                    ServiceDeploymentInfo.ServiceProtocol.TCP);
+            Assert.assertTrue(serviceDeploymentInfo.getPort() == 8080);
+            Assert.assertTrue(serviceDeploymentInfo.getDeploymentProperties().get("foo").equals("bar"));
+            if(i==0){
+                Assert.assertTrue(serviceDeploymentInfo.getDeploymentProperties().get("foo1").equals("bar1"));
+            }else {
+                Assert.assertTrue(serviceDeploymentInfo.getDeploymentProperties().get("foo2").equals("bar2"));
+            }
+        }
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("FooStream");
+
+        siddhiAppRuntime.start();
+        stockStream.send(new Object[]{"WSO2", 55.6f, 100L});
+        stockStream.send(new Object[]{"WSO2", 75.6f, 100L});
+        stockStream.send(new Object[]{"WSO2", 57.6f, 100L});
+        stockStream.send(new Object[]{"WSO2", 57.6f, 100L});
+        stockStream.send(new Object[]{"WSO2", 57.6f, 100L});
+
+        Thread.sleep(100);
+
+        //assert event count
+        AssertJUnit.assertEquals("Number of WSO2 events", 3, topic1Count.get());
+        AssertJUnit.assertEquals("Number of IBM events", 2, topic2Count.get());
+        siddhiAppRuntime.shutdown();
+
+        //unsubscribe from "inMemory" broker per topic
+        InMemoryBroker.unsubscribe(subscriptionWSO2);
+        InMemoryBroker.unsubscribe(subscriptionIBM);
+
     }
 }

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/MultiClientDistributedSinkTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/MultiClientDistributedSinkTestCase.java
@@ -646,9 +646,9 @@ public class MultiClientDistributedSinkTestCase {
                     ServiceDeploymentInfo.ServiceProtocol.TCP);
             Assert.assertTrue(serviceDeploymentInfo.getPort() == 8080);
             Assert.assertTrue(serviceDeploymentInfo.getDeploymentProperties().get("foo").equals("bar"));
-            if(i==0){
+            if (i == 0) {
                 Assert.assertTrue(serviceDeploymentInfo.getDeploymentProperties().get("foo1").equals("bar1"));
-            }else {
+            } else {
                 Assert.assertTrue(serviceDeploymentInfo.getDeploymentProperties().get("foo2").equals("bar2"));
             }
         }

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/SingleClientDistributedTransportTestCases.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/SingleClientDistributedTransportTestCases.java
@@ -19,15 +19,18 @@ package io.siddhi.core.transport;
 
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.stream.ServiceDeploymentInfo;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.config.InMemoryConfigManager;
 import io.siddhi.core.util.transport.InMemoryBroker;
 import org.apache.log4j.Logger;
+import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -91,6 +94,9 @@ public class SingleClientDistributedTransportTestCases {
 
         SiddhiManager siddhiManager = new SiddhiManager();
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        List<ServiceDeploymentInfo> serviceDeploymentInfos = siddhiAppRuntime.getSinks().
+                iterator().next().get(0).getServiceDeploymentInfoList();
+        Assert.assertEquals(serviceDeploymentInfos.size(), 0);
         InputHandler stockStream = siddhiAppRuntime.getInputHandler("FooStream");
 
         siddhiAppRuntime.start();
@@ -326,6 +332,88 @@ public class SingleClientDistributedTransportTestCases {
         //assert event count
         AssertJUnit.assertEquals("Number of topic 1 events", 6, topic1Count.get());
         AssertJUnit.assertEquals("Number of topic 2 events", 6, topic2Count.get());
+        siddhiAppRuntime.shutdown();
+
+        //unsubscribe from "inMemory" broker per topic
+        InMemoryBroker.unsubscribe(subscriptionWSO2);
+        InMemoryBroker.unsubscribe(subscriptionIBM);
+
+    }
+
+    @Test
+    public void multiClientRoundRobinWithDep() throws InterruptedException {
+        log.info("Test inMemorySink And EventMapping With SiddhiQL Dynamic Params");
+
+        InMemoryBroker.Subscriber subscriptionWSO2 = new InMemoryBroker.Subscriber() {
+            @Override
+            public void onMessage(Object msg) {
+                topic1Count.incrementAndGet();
+            }
+
+            @Override
+            public String getTopic() {
+                return "topic1";
+            }
+        };
+
+        InMemoryBroker.Subscriber subscriptionIBM = new InMemoryBroker.Subscriber() {
+            @Override
+            public void onMessage(Object msg) {
+                topic2Count.incrementAndGet();
+            }
+
+            @Override
+            public String getTopic() {
+                return "topic2";
+            }
+        };
+
+        //subscribe to "inMemory" broker per topic
+        InMemoryBroker.subscribe(subscriptionWSO2);
+        InMemoryBroker.subscribe(subscriptionIBM);
+
+        String streams = "" +
+                "@app:name('TestSiddhiApp')" +
+                "define stream FooStream (symbol string, price float, volume long); " +
+                "@sink(type='testDepInMemory', dep:foo='bar', @map(type='passThrough'), " +
+                "   @distribution(strategy='roundRobin', " +
+                "       @destination(topic = 'topic1'), " +
+                "       @destination(topic = 'topic2'))) " +
+                "define stream BarStream (symbol string, price float, volume long); ";
+
+        String query = "" +
+                "from FooStream " +
+                "select * " +
+                "insert into BarStream; ";
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        List<ServiceDeploymentInfo> serviceDeploymentInfos = siddhiAppRuntime.getSinks().
+                iterator().next().get(0).getServiceDeploymentInfoList();
+        Assert.assertEquals(serviceDeploymentInfos.size(), 1);
+        for (int i = 0; i < serviceDeploymentInfos.size(); i++) {
+            ServiceDeploymentInfo serviceDeploymentInfo = serviceDeploymentInfos.get(i);
+            Assert.assertNotNull(serviceDeploymentInfo);
+            Assert.assertTrue(serviceDeploymentInfo.isSecured());
+            Assert.assertTrue(serviceDeploymentInfo.getServiceProtocol() ==
+                    ServiceDeploymentInfo.ServiceProtocol.TCP);
+            Assert.assertTrue(serviceDeploymentInfo.getPort() == 8080);
+            Assert.assertTrue(serviceDeploymentInfo.getDeploymentProperties().get("foo").equals("bar"));
+        }
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("FooStream");
+
+        siddhiAppRuntime.start();
+        stockStream.send(new Object[]{"WSO2", 55.6f, 100L});
+        stockStream.send(new Object[]{"WSO2", 75.6f, 100L});
+        stockStream.send(new Object[]{"WSO2", 57.6f, 100L});
+        stockStream.send(new Object[]{"WSO2", 57.6f, 100L});
+        stockStream.send(new Object[]{"WSO2", 57.6f, 100L});
+
+        Thread.sleep(100);
+
+        //assert event count
+        AssertJUnit.assertEquals("Number of WSO2 events", 3, topic1Count.get());
+        AssertJUnit.assertEquals("Number of IBM events", 2, topic2Count.get());
         siddhiAppRuntime.shutdown();
 
         //unsubscribe from "inMemory" broker per topic

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/TestDepInMemorySink.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/TestDepInMemorySink.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.transport;
+
+import io.siddhi.annotation.Example;
+import io.siddhi.annotation.Extension;
+import io.siddhi.annotation.Parameter;
+import io.siddhi.annotation.util.DataType;
+import io.siddhi.core.stream.ServiceDeploymentInfo;
+import io.siddhi.core.stream.output.sink.InMemorySink;
+
+@Extension(
+        name = "testDepInMemory",
+        namespace = "sink",
+        description = "In-memory sink for testing distributed sink in multi client mode. This dummy " +
+                "sink simply overrides getSupportedDynamicOptions return nothing so that when distributed " +
+                "sink will identify it as a multi-client sink as there are no dynamic options",
+        parameters = @Parameter(name = "topic", type = DataType.STRING, description = "Event will be delivered to all" +
+                "the subscribers of the same topic"),
+        examples = @Example(
+                syntax = "@sink(type='testInMemory', @map(type='passThrough'),\n" +
+                        "@distribution(strategy='roundRobin',\n" +
+                        "@destination(topic = 'topic1'), \n" +
+                        "@destination(topic = 'topic2')))\n" +
+                        "define stream BarStream (symbol string, price float, volume long);",
+                description = "In the following example BarStream uses testInMemory transport which emit the Siddhi" +
+                        "events internally without using external transport and transformation."
+        )
+)
+public class TestDepInMemorySink extends InMemorySink {
+
+    @Override
+    protected ServiceDeploymentInfo exposedServiceDeploymentInfo() {
+        return new ServiceDeploymentInfo(8080, true);
+    }
+}

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/TestDepInMemorySource.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/TestDepInMemorySource.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c)  2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.siddhi.core.stream.input.source;
+package io.siddhi.core.transport;
 
 import io.siddhi.annotation.Example;
 import io.siddhi.annotation.Extension;
@@ -25,51 +25,63 @@ import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiAppContext;
 import io.siddhi.core.exception.ConnectionUnavailableException;
 import io.siddhi.core.stream.ServiceDeploymentInfo;
+import io.siddhi.core.stream.input.source.InMemorySource;
+import io.siddhi.core.stream.input.source.Source;
+import io.siddhi.core.stream.input.source.SourceEventListener;
 import io.siddhi.core.util.config.ConfigReader;
 import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.core.util.transport.InMemoryBroker;
 import io.siddhi.core.util.transport.OptionHolder;
-import org.apache.log4j.Logger;
 
 /**
- * Implementation of {@link Source} to receive events through in-memory transport.
+ * Implementation of {@link Source} to receive events through in-memory
+ * transport.
  */
 @Extension(
-        name = "inMemory",
+        name = "testDepInMemory",
         namespace = "source",
         description = "In-memory source that can communicate with other in-memory sinks within the same JVM, it " +
                 "is assumed that the publisher and subscriber of a topic uses same event schema (stream definition).",
         parameters = @Parameter(name = "topic", type = DataType.STRING, description = "Subscribes to sent on the "
                 + "given topic."),
         examples = @Example(
-                syntax = "@source(type='inMemory', @map(type='passThrough'))\n" +
+                syntax = "@source(type='inMemory', @map(type='passThrough'),\n" +
                         "define stream BarStream (symbol string, price float, volume long)",
                 description = "In this example BarStream uses inMemory transport which passes the received event " +
                         "internally without using external transport."
         )
 )
-public class InMemorySource extends Source {
-    private static final Logger LOG = Logger.getLogger(InMemorySource.class);
+public class TestDepInMemorySource extends InMemorySource {
     private static final String TOPIC_KEY = "topic";
-    private SourceEventListener sourceEventListener;
-    private InMemoryBroker.Subscriber subscriber;
-
-    @Override
-    protected ServiceDeploymentInfo exposeServiceDeploymentInfo() {
-        return null;
-    }
+    protected SourceEventListener sourceEventListener;
+    protected InMemoryBroker.Subscriber subscriber;
+    private String symbol;
+    private String price;
+    private String fail;
 
     @Override
     public StateFactory<State> init(SourceEventListener sourceEventListener, OptionHolder optionHolder,
                                     String[] requestedTransportPropertyNames, ConfigReader configReader,
                                     SiddhiAppContext siddhiAppContext) {
+        super.init(sourceEventListener, optionHolder, requestedTransportPropertyNames, configReader, siddhiAppContext);
+        symbol = optionHolder.validateAndGetStaticValue("prop1");
+        price = optionHolder.validateAndGetStaticValue("prop2");
+        fail = optionHolder.validateAndGetStaticValue("fail", "false");
         this.sourceEventListener = sourceEventListener;
         String topic = optionHolder.validateAndGetStaticValue(TOPIC_KEY, "input inMemory source");
         this.subscriber = new InMemoryBroker.Subscriber() {
             @Override
             public void onMessage(Object event) {
-                sourceEventListener.onEvent(event, null);
+                if (fail.equals("true")) {
+                    sourceEventListener.onEvent(event, new String[]{symbol});
+                } else {
+                    if (requestedTransportPropertyNames.length == 2 &&
+                            requestedTransportPropertyNames[0].equals("symbol") &&
+                            requestedTransportPropertyNames[1].equals("price")) {
+                        sourceEventListener.onEvent(event, new String[]{symbol, price});
+                    }
+                }
             }
 
             @Override
@@ -81,33 +93,12 @@ public class InMemorySource extends Source {
     }
 
     @Override
-    public Class[] getOutputEventClasses() {
-        return new Class[]{};
-    }
-
-    @Override
     public void connect(ConnectionCallback connectionCallback, State state) throws ConnectionUnavailableException {
         InMemoryBroker.subscribe(subscriber);
     }
 
     @Override
-    public void disconnect() {
-        InMemoryBroker.unsubscribe(subscriber);
+    protected ServiceDeploymentInfo exposeServiceDeploymentInfo() {
+        return new ServiceDeploymentInfo(ServiceDeploymentInfo.ServiceProtocol.UDP, 9000,true);
     }
-
-    @Override
-    public void destroy() {
-        // do nothing
-    }
-
-    @Override
-    public void pause() {
-        InMemoryBroker.unsubscribe(subscriber);
-    }
-
-    @Override
-    public void resume() {
-        InMemoryBroker.subscribe(subscriber);
-    }
-
 }

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/TestDepInMemorySource.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/TestDepInMemorySource.java
@@ -99,6 +99,6 @@ public class TestDepInMemorySource extends InMemorySource {
 
     @Override
     protected ServiceDeploymentInfo exposeServiceDeploymentInfo() {
-        return new ServiceDeploymentInfo(ServiceDeploymentInfo.ServiceProtocol.UDP, 9000,true);
+        return new ServiceDeploymentInfo(ServiceDeploymentInfo.ServiceProtocol.UDP, 9000, true);
     }
 }


### PR DESCRIPTION
## Purpose
> This introduces an API change to source and sink extensions, and allow them to give port, protocol and security-related information to the deployment, such as Kubernetes.

## Goals
> To make siddhi to work natively with Kubernetes. 

## Approach
> Allow Siddhi source and sink to give info to the deployment to expose the services. 
 
