### PR TITLE
Clean group by resources from snapshotable services when refreshing reading executors

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
@@ -310,6 +310,9 @@ public class IncrementalExecutor implements Executor, Snapshotable {
 
     public void clearExecutor() {
         if (isGroupBy) {
+            for (BaseIncrementalValueStore baseIncrementalValueStore : this.baseIncrementalValueStoreGroupByMap.values()) {
+                baseIncrementalValueStore.clean();
+            }
             this.baseIncrementalValueStoreGroupByMap.clear();
         } else {
             cleanBaseIncrementalValueStore(-1, this.baseIncrementalValueStore);

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
@@ -310,7 +310,8 @@ public class IncrementalExecutor implements Executor, Snapshotable {
 
     public void clearExecutor() {
         if (isGroupBy) {
-            for (BaseIncrementalValueStore baseIncrementalValueStore : this.baseIncrementalValueStoreGroupByMap.values()) {
+            for (BaseIncrementalValueStore baseIncrementalValueStore :
+                                                                this.baseIncrementalValueStoreGroupByMap.values()) {
                 baseIncrementalValueStore.clean();
             }
             this.baseIncrementalValueStoreGroupByMap.clear();


### PR DESCRIPTION
## Purpose
$subject

## Goals
To solve OOM when multiple find queries are called.

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes