### PR TITLE
Change Aggregation db writes as task execute

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExecutor.java
@@ -235,7 +235,7 @@ public class IncrementalExecutor implements Executor, Snapshotable {
                 LOG.debug("Event dispatched by " + this.duration + " incremental executor: " + eventChunk.toString());
             }
             if (isProcessingExecutor) {
-                executorService.submit(() -> table.addEvents(tableEventChunk, 1));
+                executorService.execute(() -> table.addEvents(tableEventChunk, 1));
             }
             if (getNextExecutor() != null) {
                 next.execute(eventChunk);
@@ -257,7 +257,7 @@ public class IncrementalExecutor implements Executor, Snapshotable {
                 LOG.debug("Event dispatched by " + this.duration + " incremental executor: " + eventChunk.toString());
             }
             if (isProcessingExecutor) {
-                executorService.submit(() -> table.addEvents(tableEventChunk, noOfEvents));
+                executorService.execute(() -> table.addEvents(tableEventChunk, noOfEvents));
             }
             if (getNextExecutor() != null) {
                 next.execute(eventChunk);


### PR DESCRIPTION
## Purpose
$subject , 
Fixes, exceptions in Aggregation DB writes not being logged from Siddhi 4.5.1 introduced by https://github.com/siddhi-io/siddhi/pull/1197
Fixes https://github.com/siddhi-io/siddhi/issues/1246

## Goals
Log the exceptions thrown in Aggregation DB writes

## Approach
Submit DB write tasks to Executor Service as execute

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes