### PR TITLE
Handle NPE while deleted index not exist in indexMap

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/table/holder/IndexEventHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/table/holder/IndexEventHolder.java
@@ -588,9 +588,11 @@ public class IndexEventHolder implements IndexedEventHolder, Serializable {
                     TreeMap<Object, Set<StreamEvent>> indexMap = indexData.get(indexEntry.getKey());
                     Object key = deletedEvent.getOutputData()[indexEntry.getValue()];
                     Set<StreamEvent> values = indexMap.get(key);
-                    values.remove(deletedEvent);
-                    if (values.size() == 0) {
-                        indexMap.remove(key);
+                    if (values != null) {
+                        values.remove(deletedEvent);
+                        if (values.size() == 0) {
+                            indexMap.remove(key);
+                        }
                     }
                 }
             }
@@ -603,9 +605,11 @@ public class IndexEventHolder implements IndexedEventHolder, Serializable {
                 TreeMap<Object, Set<StreamEvent>> indexMap = indexData.get(indexEntry.getKey());
                 Object key = toDeleteEvent.getOutputData()[indexEntry.getValue()];
                 Set<StreamEvent> values = indexMap.get(key);
-                values.remove(toDeleteEvent);
-                if (values.size() == 0) {
-                    indexMap.remove(key);
+                if (values != null) {
+                    values.remove(toDeleteEvent);
+                    if (values.size() == 0) {
+                        indexMap.remove(key);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Purpose
Caught NPE exception while trying to insertUpdate with conditions.

## Goals
Gracefully delete non-exist index events.