### PR TITLE
Make recreate inmemory executors efficent

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/AggregationRuntime.java
@@ -360,9 +360,9 @@ public class AggregationRuntime implements MemoryCalculable {
         incrementalDataPurging.executeIncrementalDataPurging();
     }
 
-    public void recreateInMemoryData(boolean isEventArrived, boolean refreshReadingExecutors) {
-        isFirstEventArrived = isEventArrived;
-        recreateInMemoryData.recreateInMemoryData(isEventArrived, refreshReadingExecutors);
+    public void recreateInMemoryData(boolean isFirstEventArrived, boolean refreshReadingExecutors) {
+        this.isFirstEventArrived = isFirstEventArrived;
+        recreateInMemoryData.recreateInMemoryData(isFirstEventArrived, refreshReadingExecutors);
     }
 
     public void processEvents(ComplexEventChunk<StreamEvent> streamEventComplexEventChunk) {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/RecreateInMemoryData.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/RecreateInMemoryData.java
@@ -74,7 +74,7 @@ public class RecreateInMemoryData {
         this.incrementalExecutorMapForPartitions = incrementalExecutorMapForPartitions;
     }
 
-    public void recreateInMemoryData(boolean isEventArrived, boolean refreshReadingExecutors) {
+    public void recreateInMemoryData(boolean isFirstEventArrived, boolean refreshReadingExecutors) {
         IncrementalExecutor rootExecutor = incrementalExecutorMap.get(incrementalDurations.get(0));
         if (rootExecutor.isProcessingExecutor() && rootExecutor.getNextEmitTime() != -1 && !refreshReadingExecutors) {
             // If the getNextEmitTime is not -1, that implies that a snapshot of in-memory has already been
@@ -83,7 +83,7 @@ public class RecreateInMemoryData {
             return;
         }
 
-        if (isEventArrived) {
+        if (isFirstEventArrived) {
             for (Map.Entry<TimePeriod.Duration, IncrementalExecutor> durationIncrementalExecutorEntry :
                     this.incrementalExecutorMap.entrySet()) {
                 IncrementalExecutor incrementalExecutor = durationIncrementalExecutorEntry.getValue();


### PR DESCRIPTION
## Purpose
1. Make to recreate in-memory executors efficiently. Fixes https://github.com/siddhi-io/siddhi/issues/1235
2. Change functionality where Aggregation records not being persisted to tables until calendar granularity expiry when switching from reading to processing mode.

## Approach
1. Described in https://github.com/siddhi-io/siddhi/issues/1235
2. Reset expiry time when the mode switches

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes