### PR TITLE
Improve Aggregation Recreate Inmemory Data to be more efficient

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
@@ -58,6 +58,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.siddhi.core.util.SiddhiConstants.AGG_EXTERNAL_TIMESTAMP_COL;
+import static io.siddhi.core.util.SiddhiConstants.AGG_START_TIMESTAMP_COL;
 import static io.siddhi.core.util.SiddhiConstants.UNKNOWN_STATE;
 import static io.siddhi.query.api.expression.Expression.Time.normalizeDuration;
 
@@ -298,9 +300,9 @@ public class AggregationRuntime implements MemoryCalculable {
         // Create within expression
         Expression timeFilterExpression;
         if (processingOnExternalTime) {
-            timeFilterExpression = Expression.variable("AGG_EVENT_TIMESTAMP");
+            timeFilterExpression = Expression.variable(AGG_EXTERNAL_TIMESTAMP_COL);
         } else {
-            timeFilterExpression = Expression.variable("AGG_TIMESTAMP");
+            timeFilterExpression = Expression.variable(AGG_START_TIMESTAMP_COL);
         }
         Expression withinExpression;
         Expression start = Expression.variable(additionalAttributes.get(0).getName());

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalDataPurging.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalDataPurging.java
@@ -59,8 +59,6 @@ import static io.siddhi.query.api.expression.Expression.Time.timeToLong;
  **/
 public class IncrementalDataPurging implements Runnable {
     private static final Logger LOG = Logger.getLogger(IncrementalDataPurging.class);
-    private static final String INTERNAL_AGG_TIMESTAMP_FIELD = "AGG_TIMESTAMP";
-    private static final String EXTERNAL_AGG_TIMESTAMP_FIELD = "AGG_EVENT_TIMESTAMP";
     private static final Long RETAIN_ALL = -1L;
     private static final String RETAIN_ALL_VALUES = "all";
     private long purgeExecutionInterval = Expression.Time.minute(15).value();
@@ -89,9 +87,9 @@ public class IncrementalDataPurging implements Runnable {
         this.streamEventFactory = streamEventFactory;
         this.aggregationTables = aggregationTables;
         if (isProcessingOnExternalTime) {
-            purgingTimestampField = EXTERNAL_AGG_TIMESTAMP_FIELD;
+            purgingTimestampField = SiddhiConstants.AGG_EXTERNAL_TIMESTAMP_COL;
         } else {
-            purgingTimestampField = INTERNAL_AGG_TIMESTAMP_FIELD;
+            purgingTimestampField = SiddhiConstants.AGG_START_TIMESTAMP_COL;
         }
         aggregatedTimestampAttribute = new Attribute(purgingTimestampField, Attribute.Type.LONG);
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/RecreateInMemoryData.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/RecreateInMemoryData.java
@@ -99,7 +99,7 @@ public class RecreateInMemoryData {
         Event[] events;
         Long endOFLatestEventTimestamp = null;
 
-        // Get all events from table corresponding to max duration
+        // Get max(AGG_TIMESTAMP) from table corresponding to max duration
         Table tableForMaxDuration = aggregationTables.get(incrementalDurations.get(incrementalDurations.size() - 1));
         StoreQuery storeQuery = getStoreQuery(tableForMaxDuration, true, refreshReadingExecutors,
                 endOFLatestEventTimestamp);
@@ -107,7 +107,7 @@ public class RecreateInMemoryData {
         StoreQueryRuntime storeQueryRuntime = StoreQueryParser.parse(storeQuery, siddhiAppContext, tableMap, windowMap,
                 aggregationMap);
 
-        // Get latest event timestamp in tableForMaxDuration
+        // Get latest event timestamp in tableForMaxDuration and get the end time of the aggregation record
         events = storeQueryRuntime.execute();
         if (events != null) {
             Long lastData = (Long) events[events.length - 1].getData(0);
@@ -129,6 +129,7 @@ public class RecreateInMemoryData {
 
             // Get the table previous to the duration for which we need to recreate (e.g. if we want to recreate
             // for minute duration, take the second table [provided that aggregation is done for seconds])
+            // This lookup is filtered by endOFLatestEventTimestamp
             Table recreateFromTable = aggregationTables.get(incrementalDurations.get(i - 1));
 
             storeQuery = getStoreQuery(recreateFromTable, false, refreshReadingExecutors, endOFLatestEventTimestamp);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/RecreateInMemoryData.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/RecreateInMemoryData.java
@@ -27,16 +27,17 @@ import io.siddhi.core.event.stream.StreamEventFactory;
 import io.siddhi.core.query.StoreQueryRuntime;
 import io.siddhi.core.table.Table;
 import io.siddhi.core.util.IncrementalTimeConverterUtil;
+import io.siddhi.core.util.SiddhiConstants;
 import io.siddhi.core.util.parser.StoreQueryParser;
 import io.siddhi.core.window.Window;
 import io.siddhi.query.api.aggregation.TimePeriod;
 import io.siddhi.query.api.execution.query.StoreQuery;
 import io.siddhi.query.api.execution.query.input.store.InputStore;
+import io.siddhi.query.api.execution.query.selection.OrderByAttribute;
 import io.siddhi.query.api.execution.query.selection.Selector;
 import io.siddhi.query.api.expression.Expression;
 import io.siddhi.query.api.expression.condition.Compare;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -60,7 +61,7 @@ public class RecreateInMemoryData {
                                 Map<TimePeriod.Duration, Table> aggregationTables,
                                 Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap,
                                 SiddhiAppContext siddhiAppContext, MetaStreamEvent metaStreamEvent, Map<String,
-                                Table> tableMap, Map<String, Window> windowMap,
+            Table> tableMap, Map<String, Window> windowMap,
                                 Map<String, AggregationRuntime> aggregationMap, String shardId,
                                 Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMapForPartitions) {
         this.incrementalDurations = incrementalDurations;
@@ -94,21 +95,12 @@ public class RecreateInMemoryData {
         }
 
         Event[] events;
-        Long latestEventTimestamp = null;
+        Long endOFLatestEventTimestamp = null;
 
         // Get all events from table corresponding to max duration
         Table tableForMaxDuration = aggregationTables.get(incrementalDurations.get(incrementalDurations.size() - 1));
-        StoreQuery storeQuery;
-        if (shardId == null || refreshReadingExecutors) {
-            storeQuery = StoreQuery.query().from(InputStore.store(tableForMaxDuration.getTableDefinition().getId()))
-                    .select(Selector.selector().orderBy(Expression.variable("AGG_TIMESTAMP")));
-        } else {
-            storeQuery = StoreQuery.query().from(
-                    InputStore.store(tableForMaxDuration.getTableDefinition().getId())
-                            .on(Expression.compare(Expression.variable("SHARD_ID"), Compare.Operator.EQUAL,
-                                    Expression.value(shardId))))
-                    .select(Selector.selector().orderBy(Expression.variable("AGG_TIMESTAMP")));
-        }
+        StoreQuery storeQuery = getStoreQuery(tableForMaxDuration, true, refreshReadingExecutors,
+                endOFLatestEventTimestamp);
         storeQuery.setType(StoreQuery.StoreQueryType.FIND);
         StoreQueryRuntime storeQueryRuntime = StoreQueryParser.parse(storeQuery, siddhiAppContext, tableMap, windowMap,
                 aggregationMap);
@@ -116,7 +108,9 @@ public class RecreateInMemoryData {
         // Get latest event timestamp in tableForMaxDuration
         events = storeQueryRuntime.execute();
         if (events != null) {
-            latestEventTimestamp = (Long) events[events.length - 1].getData(0);
+            Long lastData = (Long) events[events.length - 1].getData(0);
+            endOFLatestEventTimestamp = IncrementalTimeConverterUtil
+                    .getNextEmitTime(lastData, incrementalDurations.get(incrementalDurations.size() - 1), null);
         }
 
         for (int i = incrementalDurations.size() - 1; i > 0; i--) {
@@ -135,17 +129,7 @@ public class RecreateInMemoryData {
             // for minute duration, take the second table [provided that aggregation is done for seconds])
             Table recreateFromTable = aggregationTables.get(incrementalDurations.get(i - 1));
 
-            if (shardId == null || refreshReadingExecutors) {
-                storeQuery = StoreQuery.query().from(InputStore.store(recreateFromTable.getTableDefinition().getId()))
-                        .select(Selector.selector().orderBy(Expression.variable("AGG_TIMESTAMP")));
-            } else {
-                storeQuery = StoreQuery.query().from(
-                        InputStore.store(recreateFromTable.getTableDefinition().getId()).on(
-                                Expression.compare(Expression.variable("SHARD_ID"), Compare.Operator.EQUAL,
-                                        Expression.value(shardId))))
-                        .select(Selector.selector().orderBy(Expression.variable("AGG_TIMESTAMP")));
-            }
-
+            storeQuery = getStoreQuery(recreateFromTable, false, refreshReadingExecutors, endOFLatestEventTimestamp);
             storeQuery.setType(StoreQuery.StoreQueryType.FIND);
             storeQueryRuntime = StoreQueryParser.parse(storeQuery, siddhiAppContext, tableMap, windowMap,
                     aggregationMap);
@@ -153,23 +137,8 @@ public class RecreateInMemoryData {
 
             if (events != null) {
                 long referenceToNextLatestEvent = (Long) events[events.length - 1].getData(0);
-                if (latestEventTimestamp != null) {
-                    List<Event> eventsNewerThanLatestEventOfRecreateForDuration = new ArrayList<>();
-                    for (Event event : events) {
-                        // After getting the events from recreateFromTable, get the time bucket it belongs to,
-                        // if each of these events were in the recreateForDuration. This helps to identify the events,
-                        // which must be processed in-memory for recreateForDuration.
-                        long timeBucketForNextDuration = IncrementalTimeConverterUtil.getStartTimeOfAggregates(
-                                (Long) event.getData(0), recreateForDuration);
-                        if (timeBucketForNextDuration > latestEventTimestamp) {
-                            eventsNewerThanLatestEventOfRecreateForDuration.add(event);
-                        }
-                    }
-                    events = eventsNewerThanLatestEventOfRecreateForDuration.toArray(
-                            new Event[eventsNewerThanLatestEventOfRecreateForDuration.size()]);
-                }
-
-                latestEventTimestamp = referenceToNextLatestEvent;
+                endOFLatestEventTimestamp = IncrementalTimeConverterUtil
+                        .getNextEmitTime(referenceToNextLatestEvent, incrementalDurations.get(i - 1), null);
 
                 ComplexEventChunk<StreamEvent> complexEventChunk = new ComplexEventChunk<>(false);
                 for (Event event : events) {
@@ -188,12 +157,58 @@ public class RecreateInMemoryData {
                         rootIncrementalExecutor = incrementalExecutorMap.get(rootDuration);
                     }
                     long emitTimeOfLatestEventInTable = IncrementalTimeConverterUtil.getNextEmitTime(
-                            latestEventTimestamp, rootDuration, null);
+                            referenceToNextLatestEvent, rootDuration, null);
 
                     rootIncrementalExecutor.setValuesForInMemoryRecreateFromTable(emitTimeOfLatestEventInTable);
 
                 }
             }
         }
+    }
+
+    private StoreQuery getStoreQuery(Table table, boolean isLargestGranularity, boolean refreshReadingExecutors,
+                                     Long endOFLatestEventTimestamp) {
+        Selector selector = Selector.selector();
+        if (isLargestGranularity) {
+            selector = selector
+                    .orderBy(
+                            Expression.variable(SiddhiConstants.AGG_START_TIMESTAMP_COL), OrderByAttribute.Order.DESC)
+                    .limit(Expression.value(1));
+        } else {
+            selector = selector.orderBy(Expression.variable(SiddhiConstants.AGG_START_TIMESTAMP_COL));
+        }
+
+        InputStore inputStore;
+        if (shardId == null || refreshReadingExecutors) {
+            if (endOFLatestEventTimestamp == null) {
+                inputStore = InputStore.store(table.getTableDefinition().getId());
+            } else {
+                inputStore = InputStore.store(table.getTableDefinition().getId())
+                        .on(Expression.compare(
+                                Expression.variable(SiddhiConstants.AGG_START_TIMESTAMP_COL),
+                                Compare.Operator.GREATER_THAN_EQUAL,
+                                Expression.value(endOFLatestEventTimestamp)
+                        ));
+            }
+        } else {
+            if (endOFLatestEventTimestamp == null) {
+                inputStore = InputStore.store(table.getTableDefinition().getId()).on(
+                        Expression.compare(Expression.variable(SiddhiConstants.SHARD_ID_COL), Compare.Operator.EQUAL,
+                                Expression.value(shardId)));
+            } else {
+                inputStore = InputStore.store(table.getTableDefinition().getId()).on(
+                        Expression.and(
+                                Expression.compare(
+                                        Expression.variable(SiddhiConstants.SHARD_ID_COL),
+                                        Compare.Operator.EQUAL,
+                                        Expression.value(shardId)),
+                                Expression.compare(
+                                        Expression.variable(SiddhiConstants.AGG_START_TIMESTAMP_COL),
+                                        Compare.Operator.GREATER_THAN_EQUAL,
+                                        Expression.value(endOFLatestEventTimestamp))));
+            }
+        }
+
+        return StoreQuery.query().from(inputStore).select(selector);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/RecreateInMemoryData.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/RecreateInMemoryData.java
@@ -27,7 +27,6 @@ import io.siddhi.core.event.stream.StreamEventFactory;
 import io.siddhi.core.query.StoreQueryRuntime;
 import io.siddhi.core.table.Table;
 import io.siddhi.core.util.IncrementalTimeConverterUtil;
-import io.siddhi.core.util.SiddhiConstants;
 import io.siddhi.core.util.parser.StoreQueryParser;
 import io.siddhi.core.window.Window;
 import io.siddhi.query.api.aggregation.TimePeriod;
@@ -40,6 +39,9 @@ import io.siddhi.query.api.expression.condition.Compare;
 
 import java.util.List;
 import java.util.Map;
+
+import static io.siddhi.core.util.SiddhiConstants.AGG_START_TIMESTAMP_COL;
+import static io.siddhi.core.util.SiddhiConstants.SHARD_ID_COL;
 
 /**
  * This class is used to recreate in-memory data from the tables (Such as RDBMS) in incremental aggregation.
@@ -172,10 +174,10 @@ public class RecreateInMemoryData {
         if (isLargestGranularity) {
             selector = selector
                     .orderBy(
-                            Expression.variable(SiddhiConstants.AGG_START_TIMESTAMP_COL), OrderByAttribute.Order.DESC)
+                            Expression.variable(AGG_START_TIMESTAMP_COL), OrderByAttribute.Order.DESC)
                     .limit(Expression.value(1));
         } else {
-            selector = selector.orderBy(Expression.variable(SiddhiConstants.AGG_START_TIMESTAMP_COL));
+            selector = selector.orderBy(Expression.variable(AGG_START_TIMESTAMP_COL));
         }
 
         InputStore inputStore;
@@ -185,7 +187,7 @@ public class RecreateInMemoryData {
             } else {
                 inputStore = InputStore.store(table.getTableDefinition().getId())
                         .on(Expression.compare(
-                                Expression.variable(SiddhiConstants.AGG_START_TIMESTAMP_COL),
+                                Expression.variable(AGG_START_TIMESTAMP_COL),
                                 Compare.Operator.GREATER_THAN_EQUAL,
                                 Expression.value(endOFLatestEventTimestamp)
                         ));
@@ -193,17 +195,17 @@ public class RecreateInMemoryData {
         } else {
             if (endOFLatestEventTimestamp == null) {
                 inputStore = InputStore.store(table.getTableDefinition().getId()).on(
-                        Expression.compare(Expression.variable(SiddhiConstants.SHARD_ID_COL), Compare.Operator.EQUAL,
+                        Expression.compare(Expression.variable(SHARD_ID_COL), Compare.Operator.EQUAL,
                                 Expression.value(shardId)));
             } else {
                 inputStore = InputStore.store(table.getTableDefinition().getId()).on(
                         Expression.and(
                                 Expression.compare(
-                                        Expression.variable(SiddhiConstants.SHARD_ID_COL),
+                                        Expression.variable(SHARD_ID_COL),
                                         Compare.Operator.EQUAL,
                                         Expression.value(shardId)),
                                 Expression.compare(
-                                        Expression.variable(SiddhiConstants.AGG_START_TIMESTAMP_COL),
+                                        Expression.variable(AGG_START_TIMESTAMP_COL),
                                         Compare.Operator.GREATER_THAN_EQUAL,
                                         Expression.value(endOFLatestEventTimestamp))));
             }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiConstants.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiConstants.java
@@ -124,4 +124,10 @@ public final class SiddhiConstants {
     public static final String NAMESPACE_RETENTION_PERIOD = "retentionPeriod";
 
     public static final String PARTITION_ID_DEFAULT = "null";
+
+    public static final String AGG_START_TIMESTAMP_COL = "AGG_TIMESTAMP";
+    public static final String AGG_EXTERNAL_TIMESTAMP_COL = "AGG_EVENT_TIMESTAMP";
+    public static final String AGG_LAST_TIMESTAMP_COL = "AGG_LAST_EVENT_TIMESTAMP";
+    public static final String SHARD_ID_COL = "SHARD_ID";
+
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
@@ -77,16 +77,17 @@ import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
+import static io.siddhi.core.util.SiddhiConstants.AGG_EXTERNAL_TIMESTAMP_COL;
+import static io.siddhi.core.util.SiddhiConstants.AGG_LAST_TIMESTAMP_COL;
+import static io.siddhi.core.util.SiddhiConstants.AGG_START_TIMESTAMP_COL;
+import static io.siddhi.core.util.SiddhiConstants.SHARD_ID_COL;
+
 /**
  * This is the parser class of incremental aggregation definition.
  */
 public class AggregationParser {
 
     private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(AggregationParser.class);
-    private static final String AGG_START_TIMESTAMP_COL = "AGG_TIMESTAMP";
-    private static final String AGG_EXTERNAL_TIMESTAMP_COL = "AGG_EVENT_TIMESTAMP";
-    private static final String AGG_LAST_TIMESTAMP_COL = "AGG_LAST_EVENT_TIMESTAMP";
-    private static final String SHARD_ID_COL = "SHARD_ID";
 
     public static AggregationRuntime parse(AggregationDefinition aggregationDefinition,
                                            SiddhiAppContext siddhiAppContext,


### PR DESCRIPTION
## Purpose
$subject. Fix https://github.com/siddhi-io/siddhi/issues/1235

## Goals
Make recreate in-memory logic efficient so as to not select entire data in the tables.

## Approach
As mentioned in https://github.com/siddhi-io/siddhi/issues/1235

## Documentation
N/A

## Automation tests
 - Unit tests 
    Added in https://github.com/siddhi-io/siddhi-store-rdbms/pull/159, as this feature needs a persistent DB for testing

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
