### PR TITLE
[Incremental Aggregation] Optimise distributed aggregation querying

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/AggregationRuntime.java
@@ -358,7 +358,8 @@ public class AggregationRuntime implements MemoryCalculable {
                 this.tableAttributesNameList
         );
         aggregationExpressionBuilder.build(expressionVisitor);
-        Expression withinExpressionTable = Expression.and(withinExpression, expressionVisitor.getReducedExpression());
+        Expression reducedExpression = expressionVisitor.getReducedExpression();
+        Expression withinExpressionTable = Expression.and(withinExpression, reducedExpression);
         List<VariableExpressionExecutor> startEndExpressionExecutorList = new ArrayList<>();
         for (Map.Entry<TimePeriod.Duration, Table> entry : aggregationTables.entrySet()) {
             CompiledCondition withinTableCompileCondition = entry.getValue().compileCondition(withinExpressionTable,
@@ -381,13 +382,24 @@ public class AggregationRuntime implements MemoryCalculable {
         Expression lowerGranularity;
         if (isDistributed) {
             for (int i = 0; i < lowerGranularitySize; i++) {
-                lowerGranularity = Expression.and(
-                        withinExpressionTable,
-                        Expression.compare(
-                                Expression.variable("AGG_TIMESTAMP"),
-                                Compare.Operator.GREATER_THAN_EQUAL,
-                                Expression.variable(lowerGranularityAttributes.get(i)))
-                );
+                if (processingOnExternalTime) {
+                    lowerGranularity = Expression.and(
+                            Expression.compare(
+                                    Expression.variable("AGG_TIMESTAMP"),
+                                    Compare.Operator.GREATER_THAN_EQUAL,
+                                    Expression.variable(lowerGranularityAttributes.get(i))),
+                            withinExpressionTable
+                    );
+                } else {
+                    lowerGranularity = Expression.and(
+                            Expression.compare(
+                                    Expression.variable("AGG_TIMESTAMP"),
+                                    Compare.Operator.GREATER_THAN_EQUAL,
+                                    Expression.variable(lowerGranularityAttributes.get(i))),
+                            reducedExpression
+                    );
+                }
+
                 TimePeriod.Duration duration = this.incrementalDurations.get(i);
                 String tableName = aggregationName + "_" + duration.toString();
                 CompiledCondition compiledCondition = tableMap.get(tableName)

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/AggregationRuntime.java
@@ -209,9 +209,9 @@ public class AggregationRuntime implements MemoryCalculable {
                 this.recreateInMemoryData.recreateInMemoryData();
             }
             return ((IncrementalAggregateCompileCondition) compiledCondition).find(matchingEvent,
-                    aggregationDefinition, incrementalExecutorMap, aggregationTables, incrementalDurations,
-                    baseExecutors, outputExpressionExecutors, siddhiAppContext,
-                    aggregateProcessingExecutorsList, groupByKeyGeneratorList, shouldUpdateExpressionExecutor);
+                    aggregationDefinition, incrementalExecutorMap, aggregationTables, baseExecutors,
+                    outputExpressionExecutors, siddhiAppContext, aggregateProcessingExecutorsList,
+                    groupByKeyGeneratorList, shouldUpdateExpressionExecutor);
         } finally {
             SnapshotService.getSkipSnapshotableThreadLocal().set(null);
             if (latencyTrackerFind != null && Level.DETAIL.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalAggregationProcessor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalAggregationProcessor.java
@@ -74,7 +74,7 @@ public class IncrementalAggregationProcessor implements Processor {
             while (complexEventChunk.hasNext()) {
                 ComplexEvent complexEvent = complexEventChunk.next();
                 if (!isFirstEventArrived) {
-                    aggregationRuntime.recreateInMemoryDataFirstEventArrived();
+                    aggregationRuntime.recreateInMemoryData();
                     isFirstEventArrived = true;
                 }
                 StreamEvent borrowedEvent = streamEventPool.borrowEvent();

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalDataAggregator.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalDataAggregator.java
@@ -131,11 +131,13 @@ public class IncrementalDataAggregator {
         if (this.baseIncrementalValueStoreGroupByMap.size() == 0) {
             if (this.baseIncrementalValueStore.isProcessed()) {
                 processedInMemoryEventChunk.add(this.baseIncrementalValueStore.createStreamEvent());
+                this.baseIncrementalValueStore.clean();
             }
         } else {
             for (Map.Entry<String, BaseIncrementalValueStore> entryAgainstGroupBy :
                     baseIncrementalValueStoreGroupByMap.entrySet()) {
                 processedInMemoryEventChunk.add(entryAgainstGroupBy.getValue().createStreamEvent());
+                entryAgainstGroupBy.getValue().clean();
                 }
             }
         return processedInMemoryEventChunk;

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExternalTimestampDataAggregator.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/IncrementalExternalTimestampDataAggregator.java
@@ -95,6 +95,7 @@ public class IncrementalExternalTimestampDataAggregator {
         for (Map.Entry<String, BaseIncrementalValueStore> entryAgainstTime :
                 baseIncrementalValueGroupByStore.entrySet()) {
             processedInMemoryEventChunk.add(entryAgainstTime.getValue().createStreamEvent());
+            entryAgainstTime.getValue().clean();
         }
         return processedInMemoryEventChunk;
     }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/RecreateInMemoryData.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/RecreateInMemoryData.java
@@ -148,14 +148,14 @@ public class RecreateInMemoryData {
                     storeQuery = StoreQuery.query().from(
                             InputStore.store(recreateFromTable.getTableDefinition().getId()).on(
                                     Expression.and(
-                                    Expression.compare(
-                                            Expression.variable("SHARD_ID"),
-                                            Compare.Operator.EQUAL,
-                                            Expression.value(shardId)),
-                                    Expression.compare(
-                                            Expression.variable("AGG_TIMESTAMP"),
-                                            Compare.Operator.GREATER_THAN_EQUAL,
-                                            Expression.value(endOFLatestEventTimestamp)))))
+                                            Expression.compare(
+                                                    Expression.variable("SHARD_ID"),
+                                                    Compare.Operator.EQUAL,
+                                                    Expression.value(shardId)),
+                                            Expression.compare(
+                                                    Expression.variable("AGG_TIMESTAMP"),
+                                                    Compare.Operator.GREATER_THAN_EQUAL,
+                                                    Expression.value(endOFLatestEventTimestamp)))))
                             .select(Selector.selector().orderBy(Expression.variable("AGG_TIMESTAMP")));
                 }
             }
@@ -189,5 +189,6 @@ public class RecreateInMemoryData {
                 }
             }
         }
+        isRefreshed = true;
     }
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/RecreateInMemoryData.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/aggregation/RecreateInMemoryData.java
@@ -48,20 +48,20 @@ public class RecreateInMemoryData {
     private final List<TimePeriod.Duration> incrementalDurations;
     private final Map<TimePeriod.Duration, Table> aggregationTables;
     private final Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap;
-    private final Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMapForPartitions;
     private final SiddhiAppContext siddhiAppContext;
     private final StreamEventPool streamEventPool;
     private final Map<String, Table> tableMap;
     private final Map<String, Window> windowMap;
     private final Map<String, AggregationRuntime> aggregationMap;
     private final String shardId;
+    private final boolean isDistributed;
+    private boolean isRefreshed;
 
     public RecreateInMemoryData(List<TimePeriod.Duration> incrementalDurations,
             Map<TimePeriod.Duration, Table> aggregationTables,
             Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap, SiddhiAppContext siddhiAppContext,
             MetaStreamEvent metaStreamEvent, Map<String, Table> tableMap, Map<String, Window> windowMap,
-            Map<String, AggregationRuntime> aggregationMap, String shardId,
-            Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMapForPartitions) {
+            Map<String, AggregationRuntime> aggregationMap, String shardId, boolean isDistributed) {
         this.incrementalDurations = incrementalDurations;
         this.aggregationTables = aggregationTables;
         this.incrementalExecutorMap = incrementalExecutorMap;
@@ -71,37 +71,21 @@ public class RecreateInMemoryData {
         this.windowMap = windowMap;
         this.aggregationMap = aggregationMap;
         this.shardId = shardId;
-        this.incrementalExecutorMapForPartitions = incrementalExecutorMapForPartitions;
+        this.isDistributed = isDistributed;
+        this.isRefreshed = false;
     }
 
-    public void recreateInMemoryData(boolean isFirstEventArrived, boolean refreshReadingExecutors) {
-        if (!refreshReadingExecutors && isFirstEventArrived) {
-            // Only cleared when executors change from reading to processing state in one node deployment
-            for (Map.Entry<TimePeriod.Duration, IncrementalExecutor> durationIncrementalExecutorEntry :
-                    this.incrementalExecutorMap.entrySet()) {
-                IncrementalExecutor incrementalExecutor = durationIncrementalExecutorEntry.getValue();
-                incrementalExecutor.clearExecutor();
-                incrementalExecutor.setProcessingExecutor(true);
-                incrementalExecutor.setValuesForInMemoryRecreateFromTable(-1);
-            }
+    public void recreateInMemoryData() {
+        if (this.isRefreshed) {
+            return;
         }
-
-        // Clear all executors before recreating
-        Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap;
-        if (refreshReadingExecutors) {
-            incrementalExecutorMap = this.incrementalExecutorMapForPartitions;
-        } else {
-            incrementalExecutorMap = this.incrementalExecutorMap;
-        }
-        incrementalExecutorMap.forEach(((duration, incrementalExecutor) -> incrementalExecutor.clearExecutor()));
-
         Event[] events;
         Long endOFLatestEventTimestamp = null;
 
         // Get all events from table corresponding to max duration
         Table tableForMaxDuration = aggregationTables.get(incrementalDurations.get(incrementalDurations.size() - 1));
         StoreQuery storeQuery;
-        if (shardId == null || refreshReadingExecutors) {
+        if (!isDistributed) {
             storeQuery = StoreQuery.query()
                     .from(InputStore.store(tableForMaxDuration.getTableDefinition().getId()))
                     .select(Selector.selector()
@@ -138,7 +122,7 @@ public class RecreateInMemoryData {
             // for minute duration, take the second table [provided that aggregation is done for seconds])
             Table recreateFromTable = aggregationTables.get(incrementalDurations.get(i - 1));
 
-            if (shardId == null || refreshReadingExecutors) {
+            if (!isDistributed) {
                 if (endOFLatestEventTimestamp == null) {
                     storeQuery = StoreQuery.query()
                             .from(InputStore.store(recreateFromTable.getTableDefinition().getId()))

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/FindStoreQueryRuntime.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/FindStoreQueryRuntime.java
@@ -87,8 +87,6 @@ public class FindStoreQueryRuntime extends StoreQueryRuntime {
                     break;
                 case AGGREGATE:
                     stateEvent = new StateEvent(2, 0);
-                    StreamEvent streamEvent = new StreamEvent(0, 2, 0);
-                    stateEvent.addEvent(0, streamEvent);
                     streamEvents = aggregation.find(stateEvent, compiledCondition);
                     break;
                 case DEFAULT:

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
@@ -70,7 +70,7 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
     private final StreamEventPool streamEventPoolForAggregateMeta;
     private final StreamEventCloner aggregateEventCloner;
     private final List<Attribute> additionalAttributes;
-    private final List<TimePeriod.Duration> durationList;
+    private final List<TimePeriod.Duration> incrementalDurations;
 
     public IncrementalAggregateCompileCondition(
             Map<TimePeriod.Duration, CompiledCondition> withinTableCompiledConditions,
@@ -100,7 +100,7 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
         this.startTimeEndTimeExpressionExecutor = startTimeEndTimeExpressionExecutor;
         this.timestampFilterExecutors = timestampFilterExecutors;
         this.isProcessingOnExternalTime = isProcessingOnExternalTime;
-        this.durationList = incrementalDurations;
+        this.incrementalDurations = incrementalDurations;
         this.isDistributed = isDistributed;
     }
 
@@ -120,14 +120,13 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
                 inMemoryStoreCompileCondition.cloneCompilation(key), copyOfWithinTableLowerGranularityCompileCondition,
                 onCompiledCondition.cloneCompilation(key), tableMetaStreamEvent, aggregateMetaStreamEvent,
                 additionalAttributes, alteredMatchingMetaInfoHolder, perExpressionExecutor,
-                startTimeEndTimeExpressionExecutor, timestampFilterExecutors, isProcessingOnExternalTime, durationList,
-                isDistributed);
+                startTimeEndTimeExpressionExecutor, timestampFilterExecutors, isProcessingOnExternalTime,
+                incrementalDurations, isDistributed);
     }
 
     public StreamEvent find(StateEvent matchingEvent, AggregationDefinition aggregationDefinition,
                             Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap,
                             Map<TimePeriod.Duration, Table> aggregationTables,
-                            List<TimePeriod.Duration> incrementalDurations,
                             List<ExpressionExecutor> baseExecutors,
                             List<ExpressionExecutor> outputExpressionExecutors,
                             SiddhiAppContext siddhiAppContext,
@@ -194,11 +193,11 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
 
         //If processing on external time, the in-memory data also needs to be queried
         if (isDistributed) {
-            int perValueIndex = this.durationList.indexOf(perValue);
+            int perValueIndex = this.incrementalDurations.indexOf(perValue);
             if (perValueIndex != 0) {
                 Map<TimePeriod.Duration, CompiledCondition> lowerGranularityLookups = new HashMap<>();
                 for (int i = 0; i < perValueIndex; i++) {
-                    TimePeriod.Duration key = this.durationList.get(i);
+                    TimePeriod.Duration key = this.incrementalDurations.get(i);
                     lowerGranularityLookups.put(key, withinTableLowerGranularityCompileCondition.get(key));
                 }
                 List<StreamEvent> eventChunks = lowerGranularityLookups.entrySet().stream()

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
@@ -59,6 +59,7 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
     private MatchingMetaInfoHolder alteredMatchingMetaInfoHolder;
     private ExpressionExecutor perExpressionExecutor;
     private ExpressionExecutor startTimeEndTimeExpressionExecutor;
+    private List<ExpressionExecutor> timestampFilterExecutors;
     private boolean isProcessingOnExternalTime;
 
     private final StreamEventPool streamEventPoolForTableMeta;
@@ -73,7 +74,7 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
             MetaStreamEvent tableMetaStreamEvent, MetaStreamEvent aggregateMetaSteamEvent,
             List<Attribute> additionalAttributes, MatchingMetaInfoHolder alteredMatchingMetaInfoHolder,
             ExpressionExecutor perExpressionExecutor, ExpressionExecutor startTimeEndTimeExpressionExecutor,
-            boolean isProcessingOnExternalTime) {
+            List<ExpressionExecutor> timestampFilterExecutors, boolean isProcessingOnExternalTime) {
         this.withinTableCompiledConditions = withinTableCompiledConditions;
         this.inMemoryStoreCompileCondition = inMemoryStoreCompileCondition;
         this.onCompiledCondition = onCompiledCondition;
@@ -89,6 +90,7 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
         this.alteredMatchingMetaInfoHolder = alteredMatchingMetaInfoHolder;
         this.perExpressionExecutor = perExpressionExecutor;
         this.startTimeEndTimeExpressionExecutor = startTimeEndTimeExpressionExecutor;
+        this.timestampFilterExecutors = timestampFilterExecutors;
         this.isProcessingOnExternalTime = isProcessingOnExternalTime;
     }
 
@@ -102,7 +104,7 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
                 inMemoryStoreCompileCondition.cloneCompilation(key),
                 onCompiledCondition.cloneCompilation(key), tableMetaStreamEvent, aggregateMetaStreamEvent,
                 additionalAttributes, alteredMatchingMetaInfoHolder, perExpressionExecutor,
-                startTimeEndTimeExpressionExecutor, isProcessingOnExternalTime);
+                startTimeEndTimeExpressionExecutor, timestampFilterExecutors, isProcessingOnExternalTime);
     }
 
     public StreamEvent find(StateEvent matchingEvent, AggregationDefinition aggregationDefinition,
@@ -117,7 +119,30 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
                             ExpressionExecutor shouldUpdateExpressionExecutor, boolean isDistributed) {
 
         ComplexEventChunk<StreamEvent> complexEventChunkToHoldWithinMatches = new ComplexEventChunk<>(true);
+        //Create matching event if it is store Query
+        int additionTimestampAttributesSize = this.timestampFilterExecutors.size() + 2;
+        Long[] timestampFilters = new Long[additionTimestampAttributesSize];
+        if (matchingEvent.getStreamEvent(0) == null) {
+            StreamEvent streamEvent = new StreamEvent(0, additionTimestampAttributesSize, 0);
+            matchingEvent.addEvent(0, streamEvent);
+        }
 
+        Long[] startTimeEndTime = (Long[]) startTimeEndTimeExpressionExecutor.execute(matchingEvent);
+        if (startTimeEndTime == null) {
+            throw new SiddhiAppRuntimeException("Start and end times for within duration cannot be retrieved");
+        }
+        timestampFilters[0] = startTimeEndTime[0];
+        timestampFilters[1] = startTimeEndTime[1];
+
+        if (isDistributed) {
+            for (int i = 0; i < additionTimestampAttributesSize - 2; i++) {
+                timestampFilters[i + 2] = ((Long) this.timestampFilterExecutors.get(i).execute(matchingEvent));
+            }
+        }
+
+        complexEventPopulater.populateComplexEvent(matchingEvent.getStreamEvent(0), timestampFilters);
+
+        // Get all the aggregates within the given duration, from table corresponding to "per" duration
         // Retrieve per value
         String perValueAsString = perExpressionExecutor.execute(matchingEvent).toString();
         TimePeriod.Duration perValue;
@@ -139,14 +164,6 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
 
         Table tableForPerDuration = aggregationTables.get(perValue);
 
-        Long[] startTimeEndTime = (Long[]) startTimeEndTimeExpressionExecutor.execute(matchingEvent);
-        if (startTimeEndTime == null) {
-            throw new SiddhiAppRuntimeException("Start and end times for within duration cannot be retrieved");
-        }
-
-        complexEventPopulater.populateComplexEvent(matchingEvent.getStreamEvent(0), startTimeEndTime);
-
-        // Get all the aggregates within the given duration, from table corresponding to "per" duration
         StreamEvent withinMatchFromPersistedEvents = tableForPerDuration.find(matchingEvent,
                 withinTableCompiledConditions.get(perValue));
         complexEventChunkToHoldWithinMatches.add(withinMatchFromPersistedEvents);

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/AggregationParser.java
@@ -486,13 +486,6 @@ public class AggregationParser {
         ExpressionExecutor timestampExecutor = getTimeStampExecutor(siddhiAppContext, tableMap,
                 incomingVariableExpressionExecutors, aggregatorName, incomingMetaStreamEvent);
 
-        if (shardId != null) {
-            ExpressionExecutor nodeIdExpressionExecutor =
-                    new ConstantExpressionExecutor(shardId, Attribute.Type.STRING);
-            incomingExpressionExecutors.add(nodeIdExpressionExecutor);
-            incomingMetaStreamEvent.addOutputData(new Attribute(SHARD_ID_COL, Attribute.Type.STRING));
-        }
-
         Attribute timestampAttribute = new Attribute(AGG_START_TIMESTAMP_COL, Attribute.Type.LONG);
         incomingMetaStreamEvent.addOutputData(timestampAttribute);
         incomingExpressionExecutors.add(timestampExecutor);
@@ -623,6 +616,12 @@ public class AggregationParser {
                     outputExpressions.add(Expression.variable(outputAttribute.getRename()));
                 }
             }
+        }
+        if (shardId != null) {
+            ExpressionExecutor nodeIdExpressionExecutor =
+                    new ConstantExpressionExecutor(shardId, Attribute.Type.STRING);
+            incomingExpressionExecutors.add(nodeIdExpressionExecutor);
+            incomingMetaStreamEvent.addOutputData(new Attribute(SHARD_ID_COL, Attribute.Type.STRING));
         }
         return addAggLastEvent;
     }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/Aggregation1TestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/Aggregation1TestCase.java
@@ -191,7 +191,6 @@ public class Aggregation1TestCase {
                 "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
                         "quantity int, timestamp long);";
         String query = "" +
-                "@BufferSize('3') " +
                 "define aggregation stockAggregation " +
                 "from stockStream " +
                 "select symbol, avg(price) as avgPrice, sum(price) as totalPrice, (price * quantity) " +
@@ -266,7 +265,7 @@ public class Aggregation1TestCase {
             // Thursday, June 1, 2017 4:06:56 AM
             stockStreamInputHandler.send(new Object[]{"IBM", 1000f, null, 200L, 9, 1496290016000L});
 
-            Thread.sleep(100);
+            Thread.sleep(5000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 04:05:50",
                     "2017-06-01 04:06:57", "seconds"});
             Thread.sleep(100);

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/AggregationFilterTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/aggregation/AggregationFilterTestCase.java
@@ -115,7 +115,7 @@ public class AggregationFilterTestCase {
             // Thursday, June 1, 2017 5:07:56 AM
             stockStreamInputHandler.send(new Object[]{"IBM", 700f, null, 200L, 20, "2017-06-01 05:07:56"});
 
-            Thread.sleep(100);
+            Thread.sleep(5000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "minutes"});
             Thread.sleep(100);
@@ -220,7 +220,7 @@ public class AggregationFilterTestCase {
             // Thursday, June 1, 2017 5:07:56 AM
             stockStreamInputHandler.send(new Object[]{"IBM", 700f, null, 200L, 20, "2017-06-01 05:07:56"});
 
-            Thread.sleep(100);
+            Thread.sleep(5000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "minutes"});
             Thread.sleep(100);
@@ -346,7 +346,7 @@ public class AggregationFilterTestCase {
             // Monday, December 3, 2020 6:07:56 AM
             stockStreamInputHandler.send(new Object[]{"CISCO", 260f, 44f, 200L, 16, 1606975676000L});
 
-            Thread.sleep(100);
+            Thread.sleep(5000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "seconds"});
             Thread.sleep(100);
@@ -458,7 +458,7 @@ public class AggregationFilterTestCase {
 
         stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289954000L});
         stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289954000L});
-        Thread.sleep(100);
+        Thread.sleep(5000);
 
         Event[] events = siddhiAppRuntime.query("from stockAggregation " +
                 "on symbol==\"IBM\" " +


### PR DESCRIPTION
## Purpose
Optimize distributed aggregation querying

## Goals
Reduce memory consumption when distributed aggregations are queried.

## Approach
Rather than loading ongoing aggregation regardless of shard ID to the memory, the needed data (Applying on condition, within the time period) is executed on the lower granularity tables. 
However, additional time filtering is done, so as to not pick duplicate data. 

For instance,  if the find query comes at 9.30 for hour granularity, within t1 and t2, 
If Processing on external timestamp,
1. Hour table lookup as before within t1 and t2
2. a) Minute's table lookup within t1 and t2 and AGG_TIMSTAMP> 9.00
    b) Seconds table lookup within t1 and t2 and AGG_TIMESTAMP > 9.29

If processing on system timestamp, 
1. Normal hour table lookup
2. If hour ongoing aggregations start time falls within t1 and t2,
    a) Minute's table lookup with AGG_TIMSTAMP> 9.00
    b) Seconds table lookup with AGG_TIMESTAMP > 9.29

## Documentation
N/A

## Automation tests
 Since distributed aggregation test cases need a physical database, test cases are written in siddhi-store-rdbms repo. https://github.com/siddhi-io/siddhi-store-rdbms/tree/master/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes