### PR TITLE
[5x][Incremental Aggregation] Optimise distributed aggregation querying

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
@@ -158,10 +158,9 @@ public class AggregationRuntime implements MemoryCalculable {
                     streamDefinitionWithStartEnd);
         }
 
-        streamDefinitionWithStartEnd.attribute(additionalAttributes.get(0).getName(),
-                additionalAttributes.get(0).getType());
-        streamDefinitionWithStartEnd.attribute(additionalAttributes.get(1).getName(),
-                additionalAttributes.get(1).getType());
+        additionalAttributes.forEach(attribute ->
+        streamDefinitionWithStartEnd.attribute(attribute.getName(), attribute.getType())
+        );
         initMetaStreamEvent(metaStreamEventWithStartEnd, streamDefinitionWithStartEnd,
                 matchingMetaInfoHolder.getMetaStateEvent().getMetaStreamEvent(0).getInputReferenceId());
         return metaStreamEventWithStartEnd;
@@ -243,6 +242,16 @@ public class AggregationRuntime implements MemoryCalculable {
         additionalAttributes.add(new Attribute("_START", Attribute.Type.LONG));
         additionalAttributes.add(new Attribute("_END", Attribute.Type.LONG));
 
+        int durationsSize = this.incrementalDurations.size() - 1;
+        if (isDistributed) {
+            //Add additional attributes to get base aggregation timestamps based on current timestamps
+            // for values calculated in inmemory in the shards
+            for (int i = 0; i < durationsSize - 1; i++) {
+                Attribute attribute = new Attribute("_AGG_TIMESTAMP_FILTER_" + i, Attribute.Type.LONG);
+                additionalAttributes.add(attribute);
+            }
+        }
+
         // Get table definition. Table definitions for all the tables used to persist aggregates are similar.
         // Therefore it's enough to get the definition from one table.
         AbstractDefinition tableDefinition = ((Table) aggregationTables.values().toArray()[0]).getTableDefinition();
@@ -311,17 +320,6 @@ public class AggregationRuntime implements MemoryCalculable {
         Expression compareWithEndTime = Compare.compare(timeFilterExpression, Compare.Operator.LESS_THAN, end);
         withinExpression = Expression.and(compareWithStartTime, compareWithEndTime);
 
-        // Combine with and on condition for table query
-        AggregationExpressionBuilder aggregationExpressionBuilder = new AggregationExpressionBuilder(expression);
-        AggregationExpressionVisitor expressionVisitor = new AggregationExpressionVisitor(
-                newMetaStreamEventWithStartEnd.getInputReferenceId(),
-                newMetaStreamEventWithStartEnd.getLastInputDefinition().getAttributeList(),
-                this.tableAttributesNameList
-        );
-        aggregationExpressionBuilder.build(expressionVisitor);
-
-        Expression withinExpressionTable = Expression.and(withinExpression, expressionVisitor.getReducedExpression());
-
         // Create start and end time expression
         Expression startEndTimeExpression;
         ExpressionExecutor startTimeEndTimeExpressionExecutor;
@@ -342,9 +340,33 @@ public class AggregationRuntime implements MemoryCalculable {
                     "definition for filtering of aggregation data.");
         }
 
+        List<ExpressionExecutor> timestampFilterExecutors = new ArrayList<>();
+        if (isDistributed) {
+            for (int i = 0; i < durationsSize - 1; i++) {
+                Expression[] expressionArray = new Expression[]{
+                        new AttributeFunction("", "currentTimeMillis", null),
+                        Expression.value(this.incrementalDurations.get(i).toString())};
+                Expression filterExpression = new AttributeFunction("incrementalAggregator",
+                        "getAggregationStartTime", expressionArray);
+                timestampFilterExecutors.add(ExpressionParser.parseExpression(filterExpression,
+                        matchingMetaInfoHolder.getMetaStateEvent(), matchingMetaInfoHolder.getCurrentState(), tableMap,
+                        variableExpressionExecutors, false, 0,
+                        ProcessingMode.BATCH, false, siddhiQueryContext));
+            }
+        }
 
         // Create compile condition per each table used to persist aggregates.
         // These compile conditions are used to check whether the aggregates in tables are within the given duration.
+        // Combine with and on condition for table query
+        AggregationExpressionBuilder aggregationExpressionBuilder = new AggregationExpressionBuilder(expression);
+        AggregationExpressionVisitor expressionVisitor = new AggregationExpressionVisitor(
+                newMetaStreamEventWithStartEnd.getInputReferenceId(),
+                newMetaStreamEventWithStartEnd.getLastInputDefinition().getAttributeList(),
+                this.tableAttributesNameList
+        );
+        aggregationExpressionBuilder.build(expressionVisitor);
+
+        Expression withinExpressionTable = Expression.and(withinExpression, expressionVisitor.getReducedExpression());
         List<VariableExpressionExecutor> startEndExpressionExecutorList = new ArrayList<>();
         for (Map.Entry<TimePeriod.Duration, Table> entry : aggregationTables.entrySet()) {
             CompiledCondition withinTableCompileCondition = entry.getValue().compileCondition(withinExpressionTable,
@@ -374,7 +396,7 @@ public class AggregationRuntime implements MemoryCalculable {
         return new IncrementalAggregateCompileCondition(withinTableCompiledConditions, withinInMemoryCompileCondition,
                 onCompiledCondition, tableMetaStreamEvent, aggregateMetaSteamEvent, additionalAttributes,
                 alteredMatchingMetaInfoHolder, perExpressionExecutor, startTimeEndTimeExpressionExecutor,
-                processingOnExternalTime);
+                timestampFilterExecutors, processingOnExternalTime);
     }
 
     public void startPurging() {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
@@ -214,9 +214,9 @@ public class AggregationRuntime implements MemoryCalculable {
                 this.recreateInMemoryData.recreateInMemoryData();
             }
             return ((IncrementalAggregateCompileCondition) compiledCondition).find(matchingEvent,
-                    aggregationDefinition, incrementalExecutorMap, aggregationTables, incrementalDurations,
-                    baseExecutorsForFind, outputExpressionExecutors, siddhiQueryContext,
-                    aggregateProcessExpressionExecutorsListForFind, groupByKeyGeneratorList, shouldUpdateTimestamp);
+                    aggregationDefinition, incrementalExecutorMap, aggregationTables, baseExecutorsForFind,
+                    outputExpressionExecutors, siddhiQueryContext, aggregateProcessExpressionExecutorsListForFind,
+                    groupByKeyGeneratorList, shouldUpdateTimestamp);
         } finally {
             SnapshotService.getSkipStateStorageThreadLocal().set(null);
             if (latencyTrackerFind != null &&

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
@@ -439,7 +439,7 @@ public class AggregationRuntime implements MemoryCalculable {
         incrementalDataPurging.executeIncrementalDataPurging();
     }
 
-    public void recreateInMemoryData(boolean isFirstEventArrived) {
+    public synchronized void recreateInMemoryData(boolean isFirstEventArrived) {
         // State only updated when first event arrives to IncrementalAggregationProcessor
         if (isFirstEventArrived) {
             this.isFirstEventArrived = true;
@@ -448,9 +448,7 @@ public class AggregationRuntime implements MemoryCalculable {
                 durationIncrementalExecutorEntry.getValue().setProcessingExecutor(true);
             }
         }
-        synchronized (this) {
             this.recreateInMemoryData.recreateInMemoryData();
-        }
     }
 
     public void processEvents(ComplexEventChunk<StreamEvent> streamEventComplexEventChunk) {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
@@ -216,9 +216,7 @@ public class AggregationRuntime implements MemoryCalculable {
             return ((IncrementalAggregateCompileCondition) compiledCondition).find(matchingEvent,
                     aggregationDefinition, incrementalExecutorMap, aggregationTables, incrementalDurations,
                     baseExecutorsForFind, outputExpressionExecutors, siddhiQueryContext,
-                    aggregateProcessExpressionExecutorsListForFind,
-                    groupByKeyGeneratorList, shouldUpdateTimestamp,
-                    isDistributed);
+                    aggregateProcessExpressionExecutorsListForFind, groupByKeyGeneratorList, shouldUpdateTimestamp);
         } finally {
             SnapshotService.getSkipStateStorageThreadLocal().set(null);
             if (latencyTrackerFind != null &&
@@ -242,13 +240,15 @@ public class AggregationRuntime implements MemoryCalculable {
         additionalAttributes.add(new Attribute("_START", Attribute.Type.LONG));
         additionalAttributes.add(new Attribute("_END", Attribute.Type.LONG));
 
-        int durationsSize = this.incrementalDurations.size() - 1;
+        int lowerGranularitySize = this.incrementalDurations.size() - 1;
+        List<String> lowerGranularityAttributes = new ArrayList<>();
         if (isDistributed) {
             //Add additional attributes to get base aggregation timestamps based on current timestamps
             // for values calculated in inmemory in the shards
-            for (int i = 0; i < durationsSize - 1; i++) {
-                Attribute attribute = new Attribute("_AGG_TIMESTAMP_FILTER_" + i, Attribute.Type.LONG);
-                additionalAttributes.add(attribute);
+            for (int i = 0; i < lowerGranularitySize; i++) {
+                String attributeName = "_AGG_TIMESTAMP_FILTER_" + i;
+                additionalAttributes.add(new Attribute(attributeName, Attribute.Type.LONG));
+                lowerGranularityAttributes.add(attributeName);
             }
         }
 
@@ -342,10 +342,10 @@ public class AggregationRuntime implements MemoryCalculable {
 
         List<ExpressionExecutor> timestampFilterExecutors = new ArrayList<>();
         if (isDistributed) {
-            for (int i = 0; i < durationsSize - 1; i++) {
+            for (int i = 0; i < lowerGranularitySize; i++) {
                 Expression[] expressionArray = new Expression[]{
                         new AttributeFunction("", "currentTimeMillis", null),
-                        Expression.value(this.incrementalDurations.get(i).toString())};
+                        Expression.value(this.incrementalDurations.get(i + 1).toString())};
                 Expression filterExpression = new AttributeFunction("incrementalAggregator",
                         "getAggregationStartTime", expressionArray);
                 timestampFilterExecutors.add(ExpressionParser.parseExpression(filterExpression,
@@ -382,6 +382,29 @@ public class AggregationRuntime implements MemoryCalculable {
                 withinExpression, streamTableMetaInfoHolderWithStartEnd, startEndExpressionExecutorList,
                 tableMap, siddhiQueryContext);
 
+        // Create compile condition for in-memory data, in case of distributed
+        // Look at the lower level granularities
+        Map<TimePeriod.Duration, CompiledCondition> withinTableLowerGranularityCompileCondition = new HashMap<>();
+        String aggregationName = aggregationDefinition.getId();
+        Expression lowerGranularity;
+        if (isDistributed) {
+            for (int i = 0; i < lowerGranularitySize; i++) {
+                lowerGranularity = Expression.and(
+                        withinExpressionTable,
+                        Expression.compare(
+                                Expression.variable("AGG_TIMESTAMP"),
+                                Compare.Operator.GREATER_THAN_EQUAL,
+                                Expression.variable(lowerGranularityAttributes.get(i)))
+                );
+                TimePeriod.Duration duration = this.incrementalDurations.get(i);
+                String tableName = aggregationName + "_" + duration.toString();
+                CompiledCondition compiledCondition = tableMap.get(tableName).compileCondition(lowerGranularity,
+                        streamTableMetaInfoHolderWithStartEnd, startEndExpressionExecutorList, tableMap,
+                        siddhiQueryContext);
+                withinTableLowerGranularityCompileCondition.put(duration, compiledCondition);
+            }
+        }
+
         QueryParserHelper.reduceMetaComplexEvent(streamTableMetaInfoHolderWithStartEnd.getMetaStateEvent());
         QueryParserHelper.updateVariablePosition(streamTableMetaInfoHolderWithStartEnd.getMetaStateEvent(),
                 startEndExpressionExecutorList);
@@ -394,9 +417,10 @@ public class AggregationRuntime implements MemoryCalculable {
                 matchingMetaInfoHolder, variableExpressionExecutors, tableMap, siddhiQueryContext);
 
         return new IncrementalAggregateCompileCondition(withinTableCompiledConditions, withinInMemoryCompileCondition,
-                onCompiledCondition, tableMetaStreamEvent, aggregateMetaSteamEvent, additionalAttributes,
-                alteredMatchingMetaInfoHolder, perExpressionExecutor, startTimeEndTimeExpressionExecutor,
-                timestampFilterExecutors, processingOnExternalTime);
+                withinTableLowerGranularityCompileCondition, onCompiledCondition, tableMetaStreamEvent,
+                aggregateMetaSteamEvent, additionalAttributes, alteredMatchingMetaInfoHolder, perExpressionExecutor,
+                startTimeEndTimeExpressionExecutor, timestampFilterExecutors, processingOnExternalTime,
+                incrementalDurations, isDistributed);
     }
 
     public void startPurging() {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalAggregationProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalAggregationProcessor.java
@@ -76,7 +76,7 @@ public class IncrementalAggregationProcessor implements Processor {
             while (complexEventChunk.hasNext()) {
                 ComplexEvent complexEvent = complexEventChunk.next();
                 if (!isFirstEventArrived) {
-                    aggregationRuntime.recreateInMemoryDataFirstEventArrived();
+                    aggregationRuntime.recreateInMemoryData();
                     isFirstEventArrived = true;
                 }
                 StreamEvent newEvent = streamEventFactory.newInstance();

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalAggregationProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalAggregationProcessor.java
@@ -76,8 +76,8 @@ public class IncrementalAggregationProcessor implements Processor {
             while (complexEventChunk.hasNext()) {
                 ComplexEvent complexEvent = complexEventChunk.next();
                 if (!isFirstEventArrived) {
-                    aggregationRuntime.recreateInMemoryData();
                     isFirstEventArrived = true;
+                    aggregationRuntime.recreateInMemoryData(true);
                 }
                 StreamEvent newEvent = streamEventFactory.newInstance();
                 for (int i = 0; i < incomingExpressionExecutors.size(); i++) {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/RecreateInMemoryData.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/RecreateInMemoryData.java
@@ -51,21 +51,22 @@ public class RecreateInMemoryData {
     private final List<TimePeriod.Duration> incrementalDurations;
     private final Map<TimePeriod.Duration, Table> aggregationTables;
     private final Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap;
-    private final Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMapForPartitions;
     private final SiddhiAppContext siddhiAppContext;
     private final StreamEventFactory streamEventFactory;
     private final Map<String, Table> tableMap;
     private final Map<String, Window> windowMap;
     private final Map<String, AggregationRuntime> aggregationMap;
     private final String shardId;
+    private final boolean isDistributed;
+    private boolean isRefreshed;
 
     public RecreateInMemoryData(List<TimePeriod.Duration> incrementalDurations,
                                 Map<TimePeriod.Duration, Table> aggregationTables,
                                 Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap,
                                 SiddhiAppContext siddhiAppContext, MetaStreamEvent metaStreamEvent, Map<String,
             Table> tableMap, Map<String, Window> windowMap,
-                                Map<String, AggregationRuntime> aggregationMap, String shardId,
-                                Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMapForPartitions) {
+                                Map<String, AggregationRuntime> aggregationMap, String shardId, boolean isDistributed) {
+
         this.incrementalDurations = incrementalDurations;
         this.aggregationTables = aggregationTables;
         this.incrementalExecutorMap = incrementalExecutorMap;
@@ -75,37 +76,21 @@ public class RecreateInMemoryData {
         this.windowMap = windowMap;
         this.aggregationMap = aggregationMap;
         this.shardId = shardId;
-        this.incrementalExecutorMapForPartitions = incrementalExecutorMapForPartitions;
+        this.isDistributed = isDistributed;
+        this.isRefreshed = false;
     }
 
-    public void recreateInMemoryData(boolean isFirstEventArrived, boolean refreshReadingExecutors) {
-        if (!refreshReadingExecutors && isFirstEventArrived) {
+    public void recreateInMemoryData() {
+        if (this.isRefreshed) {
             // Only cleared when executors change from reading to processing state in one node deployment
-            for (Map.Entry<TimePeriod.Duration, IncrementalExecutor> durationIncrementalExecutorEntry :
-                    this.incrementalExecutorMap.entrySet()) {
-                IncrementalExecutor incrementalExecutor = durationIncrementalExecutorEntry.getValue();
-                incrementalExecutor.clearExecutor();
-                incrementalExecutor.setProcessingExecutor(true);
-                incrementalExecutor.setValuesForInMemoryRecreateFromTable(-1);
-            }
+            return;
         }
-
-        // Clear all executors before recreating
-        Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap;
-        if (refreshReadingExecutors) {
-            incrementalExecutorMap = this.incrementalExecutorMapForPartitions;
-        } else {
-            incrementalExecutorMap = this.incrementalExecutorMap;
-        }
-        incrementalExecutorMap.forEach(((duration, incrementalExecutor) -> incrementalExecutor.clearExecutor()));
-
         Event[] events;
         Long endOFLatestEventTimestamp = null;
 
         // Get max(AGG_TIMESTAMP) from table corresponding to max duration
         Table tableForMaxDuration = aggregationTables.get(incrementalDurations.get(incrementalDurations.size() - 1));
-        StoreQuery storeQuery = getStoreQuery(tableForMaxDuration, true, refreshReadingExecutors,
-                endOFLatestEventTimestamp);
+        StoreQuery storeQuery = getStoreQuery(tableForMaxDuration, true, endOFLatestEventTimestamp);
         storeQuery.setType(StoreQuery.StoreQueryType.FIND);
         StoreQueryRuntime storeQueryRuntime = StoreQueryParser.parse(storeQuery, siddhiAppContext, tableMap, windowMap,
                 aggregationMap);
@@ -128,7 +113,7 @@ public class RecreateInMemoryData {
             // This lookup is filtered by endOFLatestEventTimestamp
             Table recreateFromTable = aggregationTables.get(incrementalDurations.get(i - 1));
 
-            storeQuery = getStoreQuery(recreateFromTable, false, refreshReadingExecutors, endOFLatestEventTimestamp);
+            storeQuery = getStoreQuery(recreateFromTable, false, endOFLatestEventTimestamp);
             storeQuery.setType(StoreQuery.StoreQueryType.FIND);
             storeQueryRuntime = StoreQueryParser.parse(storeQuery, siddhiAppContext, tableMap, windowMap,
                     aggregationMap);
@@ -158,10 +143,10 @@ public class RecreateInMemoryData {
                 }
             }
         }
+        this.isRefreshed = true;
     }
 
-    private StoreQuery getStoreQuery(Table table, boolean isLargestGranularity, boolean refreshReadingExecutors,
-                                     Long endOFLatestEventTimestamp) {
+    private StoreQuery getStoreQuery(Table table, boolean isLargestGranularity, Long endOFLatestEventTimestamp) {
         Selector selector = Selector.selector();
         if (isLargestGranularity) {
             selector = selector
@@ -173,7 +158,7 @@ public class RecreateInMemoryData {
         }
 
         InputStore inputStore;
-        if (shardId == null || refreshReadingExecutors) {
+        if (!this.isDistributed) {
             if (endOFLatestEventTimestamp == null) {
                 inputStore = InputStore.store(table.getTableDefinition().getId());
             } else {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/FindStoreQueryRuntime.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/FindStoreQueryRuntime.java
@@ -92,8 +92,6 @@ public class FindStoreQueryRuntime extends StoreQueryRuntime {
                     break;
                 case AGGREGATE:
                     stateEvent = new StateEvent(2, 0);
-                    StreamEvent streamEvent = new StreamEvent(0, 2, 0);
-                    stateEvent.addEvent(0, streamEvent);
                     streamEvents = aggregation.find(stateEvent, compiledCondition, siddhiQueryContext);
                     break;
                 case DEFAULT:

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
@@ -68,7 +68,7 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
     private List<ExpressionExecutor> timestampFilterExecutors;
     private boolean isProcessingOnExternalTime;
     private final boolean isDistributed;
-    private final List<TimePeriod.Duration> durationList;
+    private final List<TimePeriod.Duration> incrementalDurations;
 
     public IncrementalAggregateCompileCondition(
             Map<TimePeriod.Duration, CompiledCondition> withinTableCompiledConditions,
@@ -97,14 +97,13 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
         this.startTimeEndTimeExpressionExecutor = startTimeEndTimeExpressionExecutor;
         this.timestampFilterExecutors = timestampFilterExecutors;
         this.isProcessingOnExternalTime = isProcessingOnExternalTime;
-        this.durationList = incrementalDurations;
+        this.incrementalDurations = incrementalDurations;
         this.isDistributed = isDistributed;
     }
 
     public StreamEvent find(StateEvent matchingEvent, AggregationDefinition aggregationDefinition,
                             Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap,
                             Map<TimePeriod.Duration, Table> aggregationTables,
-                            List<TimePeriod.Duration> incrementalDurations,
                             List<ExpressionExecutor> baseExecutorsForFind,
                             List<ExpressionExecutor> outputExpressionExecutors,
                             SiddhiQueryContext siddhiQueryContext,
@@ -170,11 +169,11 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
 
         //If processing on external time, the in-memory data also needs to be queried
         if (isDistributed) {
-            int perValueIndex = this.durationList.indexOf(perValue);
+            int perValueIndex = this.incrementalDurations.indexOf(perValue);
             if (perValueIndex != 0) {
                 Map<TimePeriod.Duration, CompiledCondition> lowerGranularityLookups = new HashMap<>();
                 for (int i = 0; i < perValueIndex; i++) {
-                    TimePeriod.Duration key = this.durationList.get(i);
+                    TimePeriod.Duration key = this.incrementalDurations.get(i);
                     lowerGranularityLookups.put(key, withinTableLowerGranularityCompileCondition.get(key));
                 }
                 List<StreamEvent> eventChunks = lowerGranularityLookups.entrySet().stream()

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
@@ -271,6 +271,33 @@ public class AggregationParser {
                             }
                     ).collect(Collectors.toList());
 
+            // GroupBy for reading
+            List<GroupByKeyGenerator> groupByKeyGeneratorListForReading;
+            if (enablePartioning && !isProcessingOnExternalTime) {
+                groupByKeyGeneratorListForReading = incrementalDurations.stream()
+                        .map(incrementalDuration -> {
+                                    List<Expression> groupByExpressionList = new ArrayList<>();
+                                    Expression timestampExpression =
+                                            AttributeFunction.function(
+                                                    "incrementalAggregator", "getAggregationStartTime",
+                                                    new Variable(AGG_START_TIMESTAMP_COL),
+                                                    new StringConstant(incrementalDuration.name())
+                                            );
+                                    groupByExpressionList.add(timestampExpression);
+                                    if (groupBy) {
+                                        groupByExpressionList.addAll(groupByVariableList.stream()
+                                                .map(groupByVariable -> (Expression) groupByVariable)
+                                                .collect(Collectors.toList()));
+                                    }
+                                    return new GroupByKeyGenerator(groupByExpressionList, processedMetaStreamEvent,
+                                            SiddhiConstants.UNKNOWN_STATE, tableMap, processVariableExpressionExecutors,
+                                            siddhiQueryContext);
+                                }
+                        ).collect(Collectors.toList());
+            } else {
+                groupByKeyGeneratorListForReading = groupByKeyGeneratorList;
+            }
+
             // Create new scheduler
             EntryValveExecutor entryValveExecutor = new EntryValveExecutor(siddhiAppContext);
             LockWrapper lockWrapper = new LockWrapper(aggregatorName);
@@ -337,7 +364,7 @@ public class AggregationParser {
                     incrementalExecutorMap, aggregationTables, ((SingleStreamRuntime) streamRuntime),
                     incrementalDurations, processedMetaStreamEvent,
                     outputExpressionExecutors, latencyTrackerFind, throughputTrackerFind, recreateInMemoryData,
-                    isProcessingOnExternalTime, groupByKeyGeneratorList,
+                    isProcessingOnExternalTime, groupByKeyGeneratorListForReading,
                     incrementalDataPurging, shouldUpdateTimestamp, enablePartioning,
                     processExpressionExecutorsListForFind);
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
@@ -175,7 +175,7 @@ public class AggregationParser {
             }
 
             ConfigManager configManager = siddhiAppContext.getSiddhiContext().getConfigManager();
-            Boolean shouldPartitionById = Boolean.parseBoolean(configManager.extractProperty("partitionById"));
+            boolean shouldPartitionById = Boolean.parseBoolean(configManager.extractProperty("partitionById"));
 
             if (enablePartioning || shouldPartitionById) {
                 shardId = configManager.extractProperty("shardId");
@@ -295,14 +295,6 @@ public class AggregationParser {
                     incrementalDurations, aggregationTables, siddhiQueryContext, aggregatorName,
                     shouldUpdateTimestamp);
 
-            Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMapForPartitions = null;
-            if (shardId != null) {
-                incrementalExecutorMapForPartitions =
-                        buildIncrementalExecutors(
-                                processedMetaStreamEvent, processExpressionExecutorsList,
-                                groupByKeyGeneratorList, incrementalDurations,
-                                aggregationTables, siddhiQueryContext, aggregatorName, shouldUpdateTimestamp);
-            }
             IncrementalDataPurging incrementalDataPurging = new IncrementalDataPurging();
             incrementalDataPurging.init(aggregationDefinition, new StreamEventFactory(processedMetaStreamEvent)
                     , aggregationTables, isProcessingOnExternalTime, siddhiQueryContext);
@@ -310,7 +302,7 @@ public class AggregationParser {
             //Recreate in-memory data from tables
             RecreateInMemoryData recreateInMemoryData = new RecreateInMemoryData(incrementalDurations,
                     aggregationTables, incrementalExecutorMap, siddhiAppContext, processedMetaStreamEvent, tableMap,
-                    windowMap, aggregationMap, shardId, incrementalExecutorMapForPartitions);
+                    windowMap, aggregationMap, shardId, enablePartioning);
 
             IncrementalExecutor rootIncrementalExecutor = incrementalExecutorMap.get(incrementalDurations.get(0));
             rootIncrementalExecutor.setScheduler(scheduler);
@@ -346,8 +338,7 @@ public class AggregationParser {
                     incrementalDurations, processedMetaStreamEvent,
                     outputExpressionExecutors, latencyTrackerFind, throughputTrackerFind, recreateInMemoryData,
                     isProcessingOnExternalTime, groupByKeyGeneratorList,
-                    incrementalDataPurging, shardId,
-                    incrementalExecutorMapForPartitions, shouldUpdateTimestamp,
+                    incrementalDataPurging, shouldUpdateTimestamp, enablePartioning,
                     processExpressionExecutorsListForFind);
 
             streamRuntime.setCommonProcessor(new IncrementalAggregationProcessor(aggregationRuntime,

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/aggregation/Aggregation1TestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/aggregation/Aggregation1TestCase.java
@@ -268,7 +268,7 @@ public class Aggregation1TestCase {
             // Thursday, June 1, 2017 4:06:56 AM
             stockStreamInputHandler.send(new Object[]{"IBM", 1000f, null, 200L, 9, 1496290016000L});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 04:05:50",
                     "2017-06-01 04:06:57", "seconds"});
             Thread.sleep(100);
@@ -398,7 +398,7 @@ public class Aggregation1TestCase {
             // Monday, August 3, 2020 6:07:56 AM
             stockStreamInputHandler.send(new Object[]{"CISCO", 260f, 44f, 200L, 16, 1596434876000L});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
 
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "seconds"});
@@ -580,7 +580,7 @@ public class Aggregation1TestCase {
             // Thursday, June 1, 2017 4:06:56 AM
             stockStreamInputHandler.send(new Object[]{"IBM", 1000f, null, 200L, 9, 1496290016000L});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "seconds"});
             Thread.sleep(100);
@@ -823,7 +823,7 @@ public class Aggregation1TestCase {
             // Monday, December 3, 2020 6:07:56 AM
             stockStreamInputHandler.send(new Object[]{"CISCO", 260f, 44f, 200L, 16, 1606975676000L});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "seconds"});
             Thread.sleep(100);
@@ -960,7 +960,7 @@ public class Aggregation1TestCase {
             // Monday, December 3, 2020 6:07:56 AM
             stockStreamInputHandler.send(new Object[]{"CISCO", 260f, 44f, 200L, 16, 1606975676000L});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "seconds"});
             Thread.sleep(100);
@@ -1121,7 +1121,7 @@ public class Aggregation1TestCase {
 
         stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289954000L});
         stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289954000L});
-        Thread.sleep(1000);
+        Thread.sleep(2000);
 
         Event[] events = siddhiAppRuntime.query("from stockAggregation " +
                 "within \"2017-06-** **:**:**\" " +
@@ -1172,7 +1172,7 @@ public class Aggregation1TestCase {
 
         stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289954000L});
         stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289954000L});
-        Thread.sleep(1000);
+        Thread.sleep(2000);
 
         Event[] events = siddhiAppRuntime.query("from stockAggregation " +
                 "within \"2017-06-** **:**:**\" " +
@@ -1281,7 +1281,7 @@ public class Aggregation1TestCase {
             stockStreamInputHandler.send(new Object[]{"IBM", 400f, null, 200L, 9, 1496289953000L});
             stockStreamInputHandler.send(new Object[]{"WSO2", 140f, null, 200L, 11, 1496289953000L});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, 1496289951000L, 1496289952001L, "seconds"});
             Thread.sleep(100);
 
@@ -1451,7 +1451,7 @@ public class Aggregation1TestCase {
         stockStreamInputHandler.send(new Object[]{"CISCO", 100f, null, 200L, 26, 1513578087000L});
         stockStreamInputHandler.send(new Object[]{"CISCO", 100f, null, 200L, 96, 1513578087000L});
 
-        Thread.sleep(1000);
+        Thread.sleep(2000);
 
         Event[] events = siddhiAppRuntime.query("from stockAggregation " +
                 "within \"2017-**-** **:**:**\" " +
@@ -1520,7 +1520,7 @@ public class Aggregation1TestCase {
         stockStreamInputHandler.send(new Object[]{"CISCO", 100f, null, 200L, 26, 1513578087000L});
         stockStreamInputHandler.send(new Object[]{"CISCO", 100f, null, 200L, 96, 1513578087000L});
 
-        Thread.sleep(1000);
+        Thread.sleep(2000);
 
         Event[] events = siddhiAppRuntime.query("from stockAggregation " +
                 "within \"2017-12-18 **:**:**\" " +
@@ -1577,7 +1577,7 @@ public class Aggregation1TestCase {
         stockStreamInputHandler.send(new Object[]{"CISCO", 100f, null, 200L, 26, 1513578087000L});
         stockStreamInputHandler.send(new Object[]{"CISCO", 100f, null, 200L, 96, 1513578087000L});
 
-        Thread.sleep(1000);
+        Thread.sleep(2000);
 
         Event[] events = siddhiAppRuntime.query("from stockAggregation " +
                 "within \"2017-12-18 06:**:**\" " +
@@ -1634,7 +1634,7 @@ public class Aggregation1TestCase {
         stockStreamInputHandler.send(new Object[]{"CISCO", 100f, null, 200L, 26, 1513578087000L});
         stockStreamInputHandler.send(new Object[]{"CISCO", 100f, null, 200L, 96, 1513578087000L});
 
-        Thread.sleep(1000);
+        Thread.sleep(2000);
 
         Event[] events = siddhiAppRuntime.query("from stockAggregation " +
                 "within \"2017-12-18 06:21:**\" " +
@@ -1691,7 +1691,7 @@ public class Aggregation1TestCase {
         stockStreamInputHandler.send(new Object[]{"CISCO", 100f, null, 200L, 26, 1513578087000L});
         stockStreamInputHandler.send(new Object[]{"CISCO", 100f, null, 200L, 96, 1513578087000L});
 
-        Thread.sleep(1000);
+        Thread.sleep(2000);
 
         Event[] events = siddhiAppRuntime.query("from stockAggregation " +
                 "within \"2017-12-18 11:51:27 +05:30\" " +
@@ -1864,7 +1864,7 @@ public class Aggregation1TestCase {
             // Thursday, June 1, 2017 5:07:56 AM
             stockStreamInputHandler.send(new Object[]{"IBM", 700f, null, 200L, 20, "2017-06-01 05:07:56"});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "minutes"});
             Thread.sleep(100);
@@ -1986,7 +1986,7 @@ public class Aggregation1TestCase {
             // Thursday, June 1, 2017 5:07:56 AM
             stockStreamInputHandler.send(new Object[]{"IBM", 700f, null, 200L, 20, "2017-06-01 05:07:56"});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "seconds"});
             Thread.sleep(100);
@@ -2126,7 +2126,7 @@ public class Aggregation1TestCase {
             // Thursday, June 1, 2017 4:05:46 AM
             stockStreamInputHandler.send(new Object[]{"IBM", 400f, null, 200L, 9, 1496289946000L});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
 
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "seconds"});
@@ -2223,7 +2223,7 @@ public class Aggregation1TestCase {
             stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289948000L});
             stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289948000L});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
 
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "seconds"});
@@ -2321,7 +2321,7 @@ public class Aggregation1TestCase {
             stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289953000L});
             stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289953000L});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
 
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
                     "2017-06-01 09:35:52 +05:30", "seconds"});
@@ -2384,7 +2384,7 @@ public class Aggregation1TestCase {
             stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289953000L});
             stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289953000L});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
 
 
             siddhiAppRuntime.query("from stockAggregation within 1496289949000L, 1496289950000L per " +
@@ -2437,7 +2437,7 @@ public class Aggregation1TestCase {
             stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289953000L});
             stockStreamInputHandler.send(new Object[]{"WSO2", 100f, null, 200L, 96, 1496289953000L});
 
-            Thread.sleep(1000);
+            Thread.sleep(2000);
 
             Event[] events = siddhiAppRuntime.query("from stockAggregation within 0L, 1496289953000L per " +
                     "'seconds' select AGG_TIMESTAMP, symbol, totalPrice");
@@ -2533,7 +2533,7 @@ public class Aggregation1TestCase {
             // Thursday, June 1, 2017 5:07:56 AM
             stockStreamInputHandler.send(new Object[]{"IBM", 700f, null, 200L, 20, "2017-06-01 11:07:56 +05:30"});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
             inputStreamInputHandler.send(new Object[]{"IBM", 1, "2016-05-30 08:35:51 +05:30",
                     "2018-06-02 10:35:52 +05:30", "months"});
             Thread.sleep(100);

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/aggregation/Aggregation2TestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/aggregation/Aggregation2TestCase.java
@@ -100,7 +100,7 @@ public class Aggregation2TestCase {
             stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289953000L});
             stockStreamInputHandler.send(new Object[]{"WSO2", 100f, null, 200L, 96, 1496289953000L});
 
-            Thread.sleep(1000);
+            Thread.sleep(2000);
             Event[] events = null;
             int i = 0;
 
@@ -171,7 +171,7 @@ public class Aggregation2TestCase {
             stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289953000L});
             stockStreamInputHandler.send(new Object[]{"WSO2", 100f, null, 200L, 96, 1496289953000L});
 
-            Thread.sleep(1000);
+            Thread.sleep(2000);
 
             Event[] events = siddhiAppRuntime.query("from stockAggregation within 0L, 1543664151000L per " +
                     "'seconds' select AGG_TIMESTAMP, symbol, totalPrice ");
@@ -290,7 +290,7 @@ public class Aggregation2TestCase {
             // Thursday, June 1, 2017 5:07:56 AM
             stockStreamInputHandler.send(new Object[]{"IBM", 700f, null, 200L, 20, "2017-06-01 05:07:56"});
 
-            Thread.sleep(100);
+            Thread.sleep(2000);
             LocalDate currentDate = LocalDate.now();
             String year = String.valueOf(currentDate.getYear());
             inputStreamInputHandler.send(new Object[]{"IBM", 1, year + "-**-** **:**:**",


### PR DESCRIPTION
## Purpose
Optimize distributed aggregation querying

## Goals
Reduce memory consumption when distributed aggregations are queried.

## Approach
Rather than loading ongoing aggregation regardless of shard ID to the memory, the needed data (Applying on condition, within the time period) is executed on the lower granularity tables. 
However, additional time filtering is done, so as to not pick duplicate data. 

For instance,  if the find query comes at 9.30 for hour granularity, within t1 and t2, 
If Processing on external timestamp,
1. Hour table lookup as before within t1 and t2
2. a) Minute's table lookup within t1 and t2 and AGG_TIMSTAMP> 9.00
    b) Seconds table lookup within t1 and t2 and AGG_TIMESTAMP > 9.29

If processing on system timestamp, 
1. Normal hour table lookup
2. If hour ongoing aggregations start time falls within t1 and t2,
    a) Minute's table lookup with AGG_TIMSTAMP> 9.00
    b) Seconds table lookup with AGG_TIMESTAMP > 9.29

## Documentation
N/A

## Automation tests
 Since distributed aggregation test cases need a physical database, test cases are written in siddhi-store-rdbms repo. https://github.com/siddhi-io/siddhi-store-rdbms/tree/master/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes