### PR TITLE
 Improve reduction of aggregation on condition

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationExpressionVisitor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationExpressionVisitor.java
@@ -50,6 +50,14 @@ public class AggregationExpressionVisitor extends BaseExpressionVisitor {
         this.allAttributesList.addAll(tableAttributesNameList);
     }
 
+    public boolean applyReducedExpression() {
+        Object peek = this.conditionOperands.peek();
+        if (peek instanceof String) {
+            return false;
+        }
+        return true;
+    }
+
     public Expression getReducedExpression() {
         Object pop = this.conditionOperands.pop();
         if (pop instanceof String) {
@@ -62,14 +70,24 @@ public class AggregationExpressionVisitor extends BaseExpressionVisitor {
     public void endVisitAnd() {
         Object rightOperand = this.conditionOperands.pop();
         Object leftOperand = this.conditionOperands.pop();
-        if (!(rightOperand instanceof String) && !(leftOperand instanceof String)) {
-            this.conditionOperands.push(
-                    Expression.and(
-                            ((Expression) leftOperand), ((Expression) rightOperand)
-                    )
-            );
+
+        boolean isLeftOperandString = leftOperand instanceof String;
+        if (isLeftOperandString) {
+            if (rightOperand instanceof String) {
+                this.conditionOperands.push("true");
+            } else {
+                this.conditionOperands.push(rightOperand);
+            }
         } else {
-            this.conditionOperands.push("true");
+            if (rightOperand instanceof String) {
+                this.conditionOperands.push(leftOperand);
+            } else {
+                this.conditionOperands.push(
+                        Expression.and(
+                                ((Expression) leftOperand), ((Expression) rightOperand)
+                        )
+                );
+            }
         }
     }
 
@@ -77,14 +95,24 @@ public class AggregationExpressionVisitor extends BaseExpressionVisitor {
     public void endVisitOr() {
         Object rightOperand = this.conditionOperands.pop();
         Object leftOperand = this.conditionOperands.pop();
-        if (!(rightOperand instanceof String) && !(leftOperand instanceof String)) {
-            this.conditionOperands.push(
-                    Expression.or(
-                            ((Expression) leftOperand), ((Expression) rightOperand)
-                    )
-            );
+
+        boolean isLeftOperandString = leftOperand instanceof String;
+        if (isLeftOperandString) {
+            if (rightOperand instanceof String) {
+                this.conditionOperands.push("true");
+            } else {
+                this.conditionOperands.push(rightOperand);
+            }
         } else {
-            this.conditionOperands.push("true");
+            if (rightOperand instanceof String) {
+                this.conditionOperands.push(leftOperand);
+            } else {
+                this.conditionOperands.push(
+                        Expression.or(
+                                ((Expression) leftOperand), ((Expression) rightOperand)
+                        )
+                );
+            }
         }
     }
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
@@ -53,6 +53,7 @@ import io.siddhi.query.api.exception.SiddhiAppValidationException;
 import io.siddhi.query.api.expression.AttributeFunction;
 import io.siddhi.query.api.expression.Expression;
 import io.siddhi.query.api.expression.condition.Compare;
+import io.siddhi.query.api.expression.constant.BoolConstant;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -355,15 +356,21 @@ public class AggregationRuntime implements MemoryCalculable {
         // Create compile condition per each table used to persist aggregates.
         // These compile conditions are used to check whether the aggregates in tables are within the given duration.
         // Combine with and on condition for table query
-        AggregationExpressionBuilder aggregationExpressionBuilder = new AggregationExpressionBuilder(expression);
-        AggregationExpressionVisitor expressionVisitor = new AggregationExpressionVisitor(
-                metaStreamEventForTableLookups.getInputReferenceId(),
-                metaStreamEventForTableLookups.getLastInputDefinition().getAttributeList(),
-                this.tableAttributesNameList
-        );
-        aggregationExpressionBuilder.build(expressionVisitor);
-        boolean shouldApplyReducedCondition = expressionVisitor.applyReducedExpression();
-        Expression reducedExpression = expressionVisitor.getReducedExpression();
+        boolean shouldApplyReducedCondition = false;
+        Expression reducedExpression = null;
+
+        //Check if there is no on conditions
+        if (!(expression instanceof BoolConstant)) {
+            AggregationExpressionBuilder aggregationExpressionBuilder = new AggregationExpressionBuilder(expression);
+            AggregationExpressionVisitor expressionVisitor = new AggregationExpressionVisitor(
+                    metaStreamEventForTableLookups.getInputReferenceId(),
+                    metaStreamEventForTableLookups.getLastInputDefinition().getAttributeList(),
+                    this.tableAttributesNameList
+            );
+            aggregationExpressionBuilder.build(expressionVisitor);
+            shouldApplyReducedCondition = expressionVisitor.applyReducedExpression();
+            reducedExpression = expressionVisitor.getReducedExpression();
+        }
 
         Expression withinExpressionTable;
         if (shouldApplyReducedCondition) {


### PR DESCRIPTION
## Purpose
$subject, When reduction is for A and B, if one of the operands is based on incremental attributes, both conditions are not passed to the DB.
If there is no 'on' condition Compile condition passed to the table is formatted as, 
AGG_TIMESTAMP<t1 and AGG_TIMESTAMP>t2 and **true**, which is changed to drop the trailing true

## Documentation
N/A

## Automation tests
Are added in https://github.com/siddhi-io/siddhi-store-rdbms as these optimizations are for physical DB's only

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
DB: H2, MySQL, MSSQL, Postgres, Oracle 11 XE, Oracle 12 SE  
