### PR TITLE
Add siddhi-runner image changing section to the k8s deployment

### DIFF
--- a/docs/documentation/siddhi-5.x/siddhi-as-a-kubernetes-microservice-5.x.md
+++ b/docs/documentation/siddhi-5.x/siddhi-as-a-kubernetes-microservice-5.x.md
@@ -108,9 +108,9 @@ siddhi    siddhi    10.0.2.15   80, 443   1m
 ```
 
 !!! Note "Custom siddhi-runner"
-    If you need to use a custom-built `siddhi-runner` image for a specific `SiddhiProcess` deployment, you have to configure `image` and `imageTag` entries with the custom-built image name and image tag respectively in the `monitor-app.yaml` file. 
+    If you need to use a custom-built `siddhi-runner` image for a specific `SiddhiProcess` deployment, you have to configure `image` and `imageTag` arguments with the custom-built image name and image tag respectively in the `monitor-app.yaml` file. 
     Refer the documentation on creating custom siddhi-runner images bundling additional JARs [here](config-guide-5.x.md#adding-to-siddhi-docker-microservice).
-    If you are pulling the custom-built image from a private Docker registry/repository, specify the corresponding kubernetes secret as `imagePullSecret` entry in the `monitor-app.yaml` file. For more details on using docker images from private registries/repositories refer [this documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 
+    If you are pulling the custom-built image from a private Docker registry/repository, specify the corresponding kubernetes secret as `imagePullSecret` argument in the `monitor-app.yaml` file. For more details on using docker images from private registries/repositories refer [this documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 
 
 **_Invoke Siddhi Applications_**
 

--- a/docs/documentation/siddhi-5.x/siddhi-as-a-kubernetes-microservice-5.x.md
+++ b/docs/documentation/siddhi-5.x/siddhi-as-a-kubernetes-microservice-5.x.md
@@ -53,7 +53,9 @@ siddhi-parser     1         1         1            1           1m
 ```
 
 !!! Note "Custom siddhi-runner"
-    If you need to change the `siddhi-runner` image for all the `SiddhiProcess` deployments, you can replace your docker image and image tag with the `SIDDHI_RUNNER_IMAGE` and `SIDDHI_RUNNER_IMAGE_TAG` environment variables in the `siddhi-operator.yaml` file. To create custom siddhi-runner image refer [this documentation](config-guide-5.x.md#adding-to-siddhi-docker-microservice). If your custom docker image from a private Docker registry or repository, then you can specify relevant kubernetes secret by changing `SIDDHI_RUNNER_IMAGE_SECRET` environment variable in the `siddhi-operator.yaml` file. For more details about the private docker images refer [this documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 
+    If you need to use a custom-built `siddhi-runner` image for all the `SiddhiProcess` deployments, you have to configure `SIDDHI_RUNNER_IMAGE` and `SIDDHI_RUNNER_IMAGE_TAG` environment variables with the custom-built image name and image tag respectively in the `siddhi-operator.yaml` file. 
+    Refer the documentation on creating custom siddhi-runner images bundling additional JARs [here](config-guide-5.x.md#adding-to-siddhi-docker-microservice).
+    If you are pulling the custom-built image from a private Docker registry/repository, specify the corresponding kubernetes secret as `SIDDHI_RUNNER_IMAGE_SECRET` environment variable in the `siddhi-operator.yaml` file. For more details on using docker images from private registries/repositories refer [this documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 
 
 ## Deploy and run Siddhi App
 
@@ -106,7 +108,9 @@ siddhi    siddhi    10.0.2.15   80, 443   1m
 ```
 
 !!! Note "Custom siddhi-runner"
-    If you need to change the `siddhi-runner` image for a specific `SiddhiProcess` deployment, you can replace your docker image and image tag with the `image` and `imageTag` entries in the `monitor-app.yaml` file. To create custom siddhi-runner image refer [this documentation](config-guide-5.x.md#adding-to-siddhi-docker-microservice). If your custom docker image from a private Docker registry or repository, then you can specify relevant kubernetes secret by changing `imagePullSecret` entry in the `siddhi-operator.yaml` file. For more details about the private docker images refer [this documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 
+    If you need to use a custom-built `siddhi-runner` image for a specific `SiddhiProcess` deployment, you have to configure `image` and `imageTag` entries with the custom-built image name and image tag respectively in the `monitor-app.yaml` file. 
+    Refer the documentation on creating custom siddhi-runner images bundling additional JARs [here](config-guide-5.x.md#adding-to-siddhi-docker-microservice).
+    If you are pulling the custom-built image from a private Docker registry/repository, specify the corresponding kubernetes secret as `imagePullSecret` entry in the `monitor-app.yaml` file. For more details on using docker images from private registries/repositories refer [this documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 
 
 **_Invoke Siddhi Applications_**
 

--- a/docs/documentation/siddhi-5.x/siddhi-as-a-kubernetes-microservice-5.x.md
+++ b/docs/documentation/siddhi-5.x/siddhi-as-a-kubernetes-microservice-5.x.md
@@ -52,6 +52,9 @@ siddhi-parser     1         1         1            1           1m
 
 ```
 
+!!! Note "Custom siddhi-runner"
+    If you need to change the `siddhi-runner` image for all the `SiddhiProcess` deployments, you can replace your docker image and image tag with the `SIDDHI_RUNNER_IMAGE` and `SIDDHI_RUNNER_IMAGE_TAG` environment variables in the `siddhi-operator.yaml` file. To create custom siddhi-runner image refer [this documentation](config-guide-5.x.md#adding-to-siddhi-docker-microservice). If your custom docker image from a private Docker registry or repository, then you can specify relevant kubernetes secret by changing `SIDDHI_RUNNER_IMAGE_SECRET` environment variable in the `siddhi-operator.yaml` file. For more details about the private docker images refer [this documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 
+
 ## Deploy and run Siddhi App
 
 Siddhi applications can be deployed on Kubernetes using the Siddhi operator. 
@@ -101,6 +104,9 @@ NAME      HOSTS     ADDRESS     PORTS     AGE
 siddhi    siddhi    10.0.2.15   80, 443   1m
 
 ```
+
+!!! Note "Custom siddhi-runner"
+    If you need to change the `siddhi-runner` image for a specific `SiddhiProcess` deployment, you can replace your docker image and image tag with the `image` and `imageTag` entries in the `monitor-app.yaml` file. To create custom siddhi-runner image refer [this documentation](config-guide-5.x.md#adding-to-siddhi-docker-microservice). If your custom docker image from a private Docker registry or repository, then you can specify relevant kubernetes secret by changing `imagePullSecret` entry in the `siddhi-operator.yaml` file. For more details about the private docker images refer [this documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 
 
 **_Invoke Siddhi Applications_**
 

--- a/docs/documentation/siddhi-5.x/siddhi-as-a-kubernetes-microservice-5.x.md
+++ b/docs/documentation/siddhi-5.x/siddhi-as-a-kubernetes-microservice-5.x.md
@@ -52,7 +52,7 @@ siddhi-parser     1         1         1            1           1m
 
 ```
 
-!!! Note "Custom siddhi-runner"
+!!! Note "Using a custom-built siddhi-runner image"
     If you need to use a custom-built `siddhi-runner` image for all the `SiddhiProcess` deployments, you have to configure `SIDDHI_RUNNER_IMAGE` and `SIDDHI_RUNNER_IMAGE_TAG` environment variables with the custom-built image name and image tag respectively in the `siddhi-operator.yaml` file. 
     Refer the documentation on creating custom siddhi-runner images bundling additional JARs [here](config-guide-5.x.md#adding-to-siddhi-docker-microservice).
     If you are pulling the custom-built image from a private Docker registry/repository, specify the corresponding kubernetes secret as `SIDDHI_RUNNER_IMAGE_SECRET` environment variable in the `siddhi-operator.yaml` file. For more details on using docker images from private registries/repositories refer [this documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 
@@ -107,7 +107,7 @@ siddhi    siddhi    10.0.2.15   80, 443   1m
 
 ```
 
-!!! Note "Custom siddhi-runner"
+!!! Note "Using a custom-built siddhi-runner image"
     If you need to use a custom-built `siddhi-runner` image for a specific `SiddhiProcess` deployment, you have to configure `image` and `imageTag` arguments with the custom-built image name and image tag respectively in the `monitor-app.yaml` file. 
     Refer the documentation on creating custom siddhi-runner images bundling additional JARs [here](config-guide-5.x.md#adding-to-siddhi-docker-microservice).
     If you are pulling the custom-built image from a private Docker registry/repository, specify the corresponding kubernetes secret as `imagePullSecret` argument in the `monitor-app.yaml` file. For more details on using docker images from private registries/repositories refer [this documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 


### PR DESCRIPTION
## Purpose
> The kubernetes deployment section of the siddhi documentation did not contain the details about how to change the default siddhi-runner image in the siddhi-operator level. 

## Goals
> Add details about the changing siddhi-runner docker image.

## Approach
> We can change docker image in two levels (operator-level and CRD level). Thus add note sections to operator deployment subsection and siddhi app deployment subsection.
