### PR TITLE
Force schedule the timer events when changing to active state

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/Scheduler.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/Scheduler.java
@@ -115,7 +115,7 @@ public class Scheduler implements ExternalReferencedHolder {
         try {
             // Insert the time into the queue
             state.toNotifyQueue.put(time);
-            schedule(time, state);     // Let the subclasses to schedule the scheduler
+            schedule(time, state, false);     // Let the subclasses to schedule the scheduler
         } catch (InterruptedException e) {
             // InterruptedException ignored if scheduledExecutorService has already been shutdown
             if (!scheduledExecutorService.isShutdown()) {
@@ -126,9 +126,9 @@ public class Scheduler implements ExternalReferencedHolder {
         }
     }
 
-    public void schedule(long time, SchedulerState state) {
+    private void schedule(long time, SchedulerState state, boolean force) {
         if (!siddhiQueryContext.getSiddhiAppContext().isPlayback()) {
-            if (!state.running && state.toNotifyQueue.size() == 1) {
+            if (!state.running && (state.toNotifyQueue.size() == 1 || force)) {
                 try {
                     mutex.acquire();
                     if (!state.running) {
@@ -168,7 +168,7 @@ public class Scheduler implements ExternalReferencedHolder {
      *
      * @param state current state
      */
-    protected void sendTimerEvents(SchedulerState state) {
+    private void sendTimerEvents(SchedulerState state) {
         Long toNotifyTime = state.toNotifyQueue.peek();
         long currentTime = siddhiQueryContext.getSiddhiAppContext().getTimestampGenerator().currentTime();
         while (toNotifyTime != null && toNotifyTime - currentTime <= 0) {
@@ -221,7 +221,7 @@ public class Scheduler implements ExternalReferencedHolder {
                         SiddhiAppContext.startPartitionFlow(allStatesEntry.getKey());
                         SiddhiAppContext.startGroupByFlow(stateEntry.getKey());
                         try {
-                            schedule(toNotifyTime, stateEntry.getValue());
+                            schedule(toNotifyTime, stateEntry.getValue(), true);
                         } finally {
                             SiddhiAppContext.stopGroupByFlow();
                             SiddhiAppContext.stopPartitionFlow();

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/snapshot/ByteSerializer.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/snapshot/ByteSerializer.java
@@ -79,7 +79,7 @@ public class ByteSerializer {
         }
         long end = System.currentTimeMillis();
         if (log.isDebugEnabled()) {
-            log.debug("Decoded in :" + (end - start) + " msec");
+            log.debug("SiddhiApp '" + siddhiAppContext.getName() + "' decoded in: " + (end - start) + " milliseconds");
         }
         return out;
     }


### PR DESCRIPTION
(cherry picked from commit 19f833f)

## Purpose
> $subject

## Approach
> forcefully schedule the 1st timer event when changing from passive to active

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes