### PR TITLE
Backport fix of eventChunk loop and StreamEvent.next() leak in in-memory

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/collection/operator/IndexOperator.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/collection/operator/IndexOperator.java
@@ -178,13 +178,16 @@ public class IndexOperator implements Operator {
                 }
                 storeEvents.add(toUpdateEventChunk);
             } else {
-                while (foundEventChunk.hasNext()) {
-                    StreamEvent streamEvent = foundEventChunk.next();
-                    streamEvent.setNext(null); // to make the chained state back to normal
+                StreamEvent first = foundEventChunk.getFirst();
+                while (first != null) {
+                    StreamEvent streamEvent = first;
                     for (Map.Entry<Integer, ExpressionExecutor> entry :
                             compiledUpdateSet.getExpressionExecutorMap().entrySet()) {
                         streamEvent.setOutputData(entry.getValue().execute(overwritingOrAddingEvent), entry.getKey());
                     }
+                    StreamEvent next = first.getNext();
+                    first.setNext(null); // to make the chained state back to normal
+                    first = next;
                 }
             }
         }

--- a/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/stream/event/ComplexEventChunkTestCase.java
+++ b/modules/siddhi-core/src/test/java/org/wso2/siddhi/core/stream/event/ComplexEventChunkTestCase.java
@@ -18,9 +18,11 @@
 
 package org.wso2.siddhi.core.stream.event;
 
+import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.siddhi.core.event.ComplexEventChunk;
 import org.wso2.siddhi.core.event.stream.StreamEvent;
 import org.wso2.siddhi.core.event.stream.StreamEventPool;
 import org.wso2.siddhi.core.event.stream.converter.ConversionStreamEventChunk;
@@ -216,5 +218,38 @@ public class ComplexEventChunkTestCase {
         streamEventChunk.remove();
     }
 
+    @Test
+    public void eventChunkTest5() {
+        //Test self looping events
+
+        ComplexEventChunk<StreamEvent> complexEventChunk = new ComplexEventChunk<>(true);
+
+        StreamEvent streamEvent1 = new StreamEvent(0, 0, 3);
+        streamEvent1.setOutputData(new Object[]{"IBM", 100L, 100L});
+
+        StreamEvent streamEvent2 = new StreamEvent(0, 0, 3);
+        streamEvent2.setOutputData(new Object[]{"WSO2", 200L, 100L});
+
+        StreamEvent streamEvent3 = new StreamEvent(0, 0, 3);
+        streamEvent3.setOutputData(new Object[]{"WSO2", 300L, 100L});
+
+        StreamEvent streamEvent4 = new StreamEvent(0, 0, 3);
+        streamEvent4.setOutputData(new Object[]{"WSO2", 400L, 100L});
+
+        streamEvent1.setNext(streamEvent2);
+        streamEvent2.setNext(streamEvent3);
+        streamEvent3.setNext(streamEvent4);
+        streamEvent4.setNext(streamEvent1);
+        complexEventChunk.add(streamEvent1);
+
+        Assert.assertTrue(complexEventChunk.getLast().getNext() == null);
+
+        while (complexEventChunk.hasNext()) {
+            count++;
+            complexEventChunk.next();
+        }
+
+        Assert.assertEquals(count, 4, "Event Count");
+    }
 
 }


### PR DESCRIPTION
cherry pick from 90499831217d827bf438bdd33c59f9ae7948abf7 and a7e4a38fef81b91a0404ac2c913c1aa973659313
