### PR TITLE
Optimizing the getAttributeNameArray() by overriding the base implementation to remove hotstop on this method

### DIFF
--- a/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/definition/StreamDefinition.java
+++ b/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/definition/StreamDefinition.java
@@ -42,6 +42,7 @@ public class StreamDefinition extends AbstractDefinition {
     public StreamDefinition attribute(String attributeName, Attribute.Type type) {
         checkAttribute(attributeName);
         this.attributeList.add(new Attribute(attributeName, type));
+        this.hasDefinitionChanged = true;
         return this;
     }
     

--- a/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/definition/StreamDefinition.java
+++ b/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/definition/StreamDefinition.java
@@ -25,7 +25,9 @@ import io.siddhi.query.api.annotation.Annotation;
 public class StreamDefinition extends AbstractDefinition {
 
     private static final long serialVersionUID = 1L;
-
+    protected String[] attributeNameArray;
+    protected boolean hasDefinitionChanged = false;
+    
     public StreamDefinition() {
     }
 
@@ -41,6 +43,24 @@ public class StreamDefinition extends AbstractDefinition {
         checkAttribute(attributeName);
         this.attributeList.add(new Attribute(attributeName, type));
         return this;
+    }
+    
+    // overriding the base implementation to remove hotspot on this method call
+    // iterating the attribute list only if there is a change
+    @Override
+    public String[] getAttributeNameArray() {
+    	
+    	if (hasDefinitionChanged) {
+    		int attributeListSize = attributeList.size();
+            this.attributeNameArray = new String[attributeListSize];
+            for (int i = 0; i < attributeListSize; i++) {
+                this.attributeNameArray[i] = attributeList.get(i).getName();
+            }
+            
+            hasDefinitionChanged = false;
+    	}
+        
+        return this.attributeNameArray;
     }
 
     public StreamDefinition annotation(Annotation annotation) {


### PR DESCRIPTION
## Purpose

This getAttributeNameArray() method from the base implementation is called on every event occurrence where it iterates the attribute list and results in a hotstop when there is huge load of events. This should be optimised.

## Goals
Optimizing getAttributeNameArray() method to compute the attribute list only once when the stream definition changes and not on every call to remove the hotstop.

## Approach
Overriding the base implementation in the derived class to compute the attribute list only once when the stream definition changes and not on every event occurrence.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> Tested on JDK 8 on Linux.
 
