### PR TITLE
Performance Improvement for Stream Definition Attribute Array Name list retrieval

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -77,7 +77,7 @@
         <Bug pattern="VO_VOLATILE_INCREMENT"/>
     </Match>
     <Match>
-        <Class name="PartitionRuntime"/>
+        <Class name="io.siddhi.core.partition.PartitionRuntime"/>
         <Bug pattern="RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED"/>
     </Match>
     <Match>

--- a/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/definition/StreamDefinition.java
+++ b/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/definition/StreamDefinition.java
@@ -50,17 +50,16 @@ public class StreamDefinition extends AbstractDefinition {
     // iterating the attribute list only if there is a change
     @Override
     public String[] getAttributeNameArray() {
-    	
-    	if (hasDefinitionChanged) {
-    		int attributeListSize = attributeList.size();
+        if (hasDefinitionChanged) {
+            int attributeListSize = attributeList.size();
             this.attributeNameArray = new String[attributeListSize];
             for (int i = 0; i < attributeListSize; i++) {
                 this.attributeNameArray[i] = attributeList.get(i).getName();
             }
-            
+
             hasDefinitionChanged = false;
-    	}
-        
+        }
+
         return this.attributeNameArray;
     }
 

--- a/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/definition/StreamDefinition.java
+++ b/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/definition/StreamDefinition.java
@@ -42,6 +42,7 @@ public class StreamDefinition extends AbstractDefinition {
     public StreamDefinition attribute(String attributeName, Attribute.Type type) {
         checkAttribute(attributeName);
         this.attributeList.add(new Attribute(attributeName, type));
+        this.hasDefinitionChanged = true;
         return this;
     }
     

--- a/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/definition/StreamDefinition.java
+++ b/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/definition/StreamDefinition.java
@@ -25,7 +25,9 @@ import io.siddhi.query.api.annotation.Annotation;
 public class StreamDefinition extends AbstractDefinition {
 
     private static final long serialVersionUID = 1L;
-
+    protected String[] attributeNameArray;
+    protected boolean hasDefinitionChanged = false;
+    
     public StreamDefinition() {
     }
 
@@ -41,6 +43,24 @@ public class StreamDefinition extends AbstractDefinition {
         checkAttribute(attributeName);
         this.attributeList.add(new Attribute(attributeName, type));
         return this;
+    }
+    
+    // overriding the base implementation to remove hotspot on this method call
+    // iterating the attribute list only if there is a change
+    @Override
+    public String[] getAttributeNameArray() {
+    	
+    	if (hasDefinitionChanged) {
+    		int attributeListSize = attributeList.size();
+            this.attributeNameArray = new String[attributeListSize];
+            for (int i = 0; i < attributeListSize; i++) {
+                this.attributeNameArray[i] = attributeList.get(i).getName();
+            }
+            
+            hasDefinitionChanged = false;
+    	}
+        
+        return this.attributeNameArray;
     }
 
     public StreamDefinition annotation(Annotation annotation) {


### PR DESCRIPTION
## Purpose
> This getAttributeNameArray() method from the base implementation is called on every event occurrence where it iterates the attribute list and results in a hotstop when there is huge load of events. This should be optimised.

## Goals
> Optimizing getAttributeNameArray() method to compute the attribute list only once when the stream definition changes and not on every call to remove the hotstop.

## Approach
> Overriding the base implementation in the derived class to compute the attribute list only once when the stream definition changes and not on every event occurrence.
