### PR TITLE
Validate mandatory parameter mismatch in annotation.

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/processor/stream/function/Pol2CartStreamFunctionProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/processor/stream/function/Pol2CartStreamFunctionProcessor.java
@@ -59,7 +59,6 @@ import java.util.List;
                         defaultValue = "If z value is not given, drop the third parameter of the output.")
         },
         parameterOverloads = {
-                @ParameterOverload(),
                 @ParameterOverload(parameterNames = {"theta", "rho"}),
                 @ParameterOverload(parameterNames = {"theta", "rho", "z"})
         },

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/processor/stream/window/LossyFrequentWindowProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/processor/stream/window/LossyFrequentWindowProcessor.java
@@ -64,6 +64,8 @@ import java.util.concurrent.ConcurrentHashMap;
                         type = {DataType.DOUBLE}),
                 @Parameter(name = "error.bound",
                         description = "The error bound value.",
+                        optional = true,
+                        defaultValue = "`support.threshold`/10",
                         type = {DataType.DOUBLE}),
                 @Parameter(name = "attribute",
                         description = "The attributes to group the events. If no attributes are given, " +

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/processor/stream/window/SortWindowProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/processor/stream/window/SortWindowProcessor.java
@@ -74,7 +74,6 @@ import java.util.Map;
                         description = "The attribute that should be checked for the order.",
                         type = {DataType.STRING, DataType.DOUBLE, DataType.INT, DataType.LONG, DataType.FLOAT,
                         DataType.LONG},
-                        optional = true,
                         dynamic = true,
                         defaultValue = "The concatenation of all the attributes of the event is considered."),
                 @Parameter(name = "order",

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/validator/InputParameterValidator.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/validator/InputParameterValidator.java
@@ -77,9 +77,8 @@ public class InputParameterValidator {
         for (ParameterOverload aParameterOverload : parameterOverloads) {
             String[] overloadParameterNames = aParameterOverload.parameterNames();
             if (overloadParameterNames.length == attributeExpressionExecutors.length &&
-                    ((overloadParameterNames.length == 0) || (overloadParameterNames.length > 0)
-                            && !(overloadParameterNames[overloadParameterNames.length - 1].
-                            equals(REPETITIVE_PARAMETER_NOTATION)))) {
+                    (overloadParameterNames.length == 0 || !overloadParameterNames[overloadParameterNames.length - 1].
+                            equals(REPETITIVE_PARAMETER_NOTATION))) {
                 boolean isExpectedParameterOverload = true;
                 for (int i = 0; i < overloadParameterNames.length; i++) {
                     String overloadParameterName = overloadParameterNames[i];


### PR DESCRIPTION
## Purpose
> To make sure the docs are consistent and correct.

## Approach
> Validate mandatory parameter mismatch between ParameterOverload and 'optional' annotation.

## Release note
> Validate mandatory parameter mismatch in Extension annotations.

