### PR TITLE
Add source type to source handler

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/SourceHandlerManager.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/SourceHandlerManager.java
@@ -31,7 +31,7 @@ public abstract class SourceHandlerManager {
      */
     private HashMap<String, SourceHandler> registeredSourceHandlers = new HashMap<>();
 
-    public abstract SourceHandler generateSourceHandler();
+    public abstract SourceHandler generateSourceHandler(String type);
 
     public void registerSourceHandler(String elementId, SourceHandler sourceHandler) {
         this.registeredSourceHandlers.put(elementId, sourceHandler);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/helper/DefinitionParserHelper.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/helper/DefinitionParserHelper.java
@@ -337,7 +337,7 @@ public class DefinitionParserHelper {
                             getSourceHandlerManager();
                     SourceHandler sourceHandler = null;
                     if (sourceHandlerManager != null) {
-                        sourceHandler = sourceHandlerManager.generateSourceHandler();
+                        sourceHandler = sourceHandlerManager.generateSourceHandler(sourceType);
                     }
                     // load input transport extension
                     Extension sourceExtension = constructExtension(streamDefinition, SiddhiConstants.ANNOTATION_SOURCE,


### PR DESCRIPTION
## Purpose
This PR adds `sourceType` parameter to the `SourceHandler. generateSourceHandler()` method.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
