### PR TITLE
Support list of values as the output of counting-pattern 

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/event/stream/MetaStreamEvent.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/event/stream/MetaStreamEvent.java
@@ -39,6 +39,8 @@ public class MetaStreamEvent implements MetaComplexEvent {
     private String inputReferenceId;
     private StreamDefinition outputStreamDefinition;
     private EventType eventType = EventType.DEFAULT;
+    //Event has the possibility to produce multiple values
+    private boolean multiValue = false;
 
     public List<Attribute> getBeforeWindowData() {
         return beforeWindowData;
@@ -143,6 +145,14 @@ public class MetaStreamEvent implements MetaComplexEvent {
         return inputDefinitions.get(inputDefinitions.size() - 1);
     }
 
+    public boolean isMultiValue() {
+        return multiValue;
+    }
+
+    public void setMultiValue(boolean multiValue) {
+        this.multiValue = multiValue;
+    }
+
     /**
      * Type of Meta Events
      */
@@ -162,12 +172,13 @@ public class MetaStreamEvent implements MetaComplexEvent {
         }
         metaStreamEvent.beforeWindowData = new ArrayList<>(beforeWindowData);
 
-        for (AbstractDefinition abstractDefinition: this.getInputDefinitions()) {
+        for (AbstractDefinition abstractDefinition : this.getInputDefinitions()) {
             metaStreamEvent.addInputDefinition(abstractDefinition);
         }
         metaStreamEvent.setInputReferenceId(this.getInputReferenceId());
         metaStreamEvent.setOutputDefinition(this.getOutputStreamDefinition());
         metaStreamEvent.setEventType(this.getEventType());
+        metaStreamEvent.setMultiValue(this.isMultiValue());
         return metaStreamEvent;
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/executor/MultiValueVariableFunctionExecutor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/executor/MultiValueVariableFunctionExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/executor/MultiValueVariableFunctionExecutor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/executor/MultiValueVariableFunctionExecutor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.executor;
+
+import io.siddhi.core.config.SiddhiQueryContext;
+import io.siddhi.core.event.ComplexEvent;
+import io.siddhi.core.event.state.StateEvent;
+import io.siddhi.core.event.stream.StreamEvent;
+import io.siddhi.core.executor.function.FunctionExecutor;
+import io.siddhi.core.util.config.ConfigReader;
+import io.siddhi.core.util.snapshot.state.State;
+import io.siddhi.core.util.snapshot.state.StateFactory;
+import io.siddhi.query.api.definition.Attribute;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Executor class for Siddhi event attribute that produces multiple values.
+ * This executor is used to extract multiple attribute values as a list from
+ * {@link ComplexEvent}.
+ */
+public class MultiValueVariableFunctionExecutor extends FunctionExecutor {
+
+    int[] position;
+
+    @Override
+    protected StateFactory init(ExpressionExecutor[] attributeExpressionExecutors, ConfigReader configReader,
+                                SiddhiQueryContext siddhiQueryContext) {
+        position = ((VariableExpressionExecutor) attributeExpressionExecutors[0]).getPosition();
+        return null;
+    }
+
+    @Override
+    public Attribute.Type getReturnType() {
+        return Attribute.Type.OBJECT;
+    }
+
+    @Override
+    protected Object execute(Object[] data, State state) {
+        //will not occur
+        return null;
+    }
+
+    @Override
+    protected Object execute(Object data, State state) {
+        //will not occur
+        return null;
+    }
+
+    public Object execute(ComplexEvent event) {
+        List values = new LinkedList();
+        StreamEvent aEvent = ((StateEvent) event).getStreamEvent(position);
+        while (aEvent != null) {
+            values.add(aEvent.getAttribute(position));
+            aEvent = aEvent.getNext();
+        }
+        return values;
+    }
+
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiConstants.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiConstants.java
@@ -118,6 +118,7 @@ public final class SiddhiConstants {
     public static final String EXTENSION_SEPARATOR = ":";
 
     public static final String KEY_DELIMITER = ":-:";
+    public static final String KEY_DELIMITER_FILE = "-_-";
     public static final String TRANSPORT_CHANNEL_CREATION_IDENTIFIER = "transportChannelCreationEnabled";
 
     public static final String NAMESPACE_PURGE = "purge";

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/InputStreamParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/InputStreamParser.java
@@ -58,7 +58,6 @@ public class InputStreamParser {
      * @param outputExpectsExpiredEvents is expired events sent as output
      * @param siddhiQueryContext         Siddhi query context.
      * @return StreamRuntime
-
      */
     public static StreamRuntime parse(InputStream inputStream, Query query,
                                       Map<String, AbstractDefinition> streamDefinitionMap,
@@ -84,7 +83,7 @@ public class InputStreamParser {
                     executors, streamDefinitionMap,
                     tableDefinitionMap, windowDefinitionMap, aggregationDefinitionMap, tableMap,
                     new MetaStreamEvent(), processStreamReceiver, true,
-                    outputExpectsExpiredEvents, false, siddhiQueryContext);
+                    outputExpectsExpiredEvents, false, false, siddhiQueryContext);
         } else if (inputStream instanceof JoinInputStream) {
             return JoinInputStreamParser.parseInputStream(((JoinInputStream) inputStream),
                     query, streamDefinitionMap, tableDefinitionMap, windowDefinitionMap,

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/JoinInputStreamParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/JoinInputStreamParser.java
@@ -157,7 +157,7 @@ public class JoinInputStreamParser {
                     leftMetaStreamEvent.getEventType() != WINDOW ? null : windowDefinitionMap,
                     leftMetaStreamEvent.getEventType() != AGGREGATE ? null : aggregationDefinitionMap,
                     tableMap, leftMetaStreamEvent, leftProcessStreamReceiver, true,
-                    outputExpectsExpiredEvents, true, siddhiQueryContext);
+                    outputExpectsExpiredEvents, true, false, siddhiQueryContext);
 
             for (VariableExpressionExecutor variableExpressionExecutor : executors) {
                 variableExpressionExecutor.getPosition()[SiddhiConstants.STREAM_EVENT_CHAIN_INDEX] = 0;
@@ -171,7 +171,7 @@ public class JoinInputStreamParser {
                     rightMetaStreamEvent.getEventType() != WINDOW ? null : windowDefinitionMap,
                     rightMetaStreamEvent.getEventType() != AGGREGATE ? null : aggregationDefinitionMap,
                     tableMap, rightMetaStreamEvent, rightProcessStreamReceiver, true,
-                    outputExpectsExpiredEvents, true, siddhiQueryContext);
+                    outputExpectsExpiredEvents, true, false, siddhiQueryContext);
 
             for (int i = size; i < executors.size(); i++) {
                 VariableExpressionExecutor variableExpressionExecutor = executors.get(i);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/SingleInputStreamParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/SingleInputStreamParser.java
@@ -76,6 +76,7 @@ public class SingleInputStreamParser {
      * @param supportsBatchProcessing     supports batch processing
      * @param outputExpectsExpiredEvents  is expired events sent as output
      * @param findToBeExecuted            find will be executed in the steam stores
+     * @param multiValue                  event has the possibility to produce multiple values
      * @param siddhiQueryContext          @return SingleStreamRuntime
      */
     public static SingleStreamRuntime parseInputStream(SingleInputStream inputStream,
@@ -90,6 +91,7 @@ public class SingleInputStreamParser {
                                                        boolean supportsBatchProcessing,
                                                        boolean outputExpectsExpiredEvents,
                                                        boolean findToBeExecuted,
+                                                       boolean multiValue,
                                                        SiddhiQueryContext siddhiQueryContext) {
         Processor processor = null;
         EntryValveProcessor entryValveProcessor = null;
@@ -100,11 +102,11 @@ public class SingleInputStreamParser {
             metaStreamEvent = new MetaStreamEvent();
             ((MetaStateEvent) metaComplexEvent).addEvent(metaStreamEvent);
             initMetaStreamEvent(inputStream, streamDefinitionMap, tableDefinitionMap, windowDefinitionMap,
-                    aggregationDefinitionMap, metaStreamEvent);
+                    aggregationDefinitionMap, multiValue, metaStreamEvent);
         } else {
             metaStreamEvent = (MetaStreamEvent) metaComplexEvent;
             initMetaStreamEvent(inputStream, streamDefinitionMap, tableDefinitionMap, windowDefinitionMap,
-                    aggregationDefinitionMap, metaStreamEvent);
+                    aggregationDefinitionMap, multiValue, metaStreamEvent);
         }
 
         // A window cannot be defined for a window stream
@@ -252,6 +254,7 @@ public class SingleInputStreamParser {
      * @param streamDefinitionMap      StreamDefinition Map
      * @param tableDefinitionMap       TableDefinition Map
      * @param aggregationDefinitionMap AggregationDefinition Map
+     * @param multiValue               Event has the possibility to produce multiple values
      * @param metaStreamEvent          MetaStreamEvent
      */
     private static void initMetaStreamEvent(SingleInputStream inputStream,
@@ -259,7 +262,7 @@ public class SingleInputStreamParser {
                                             Map<String, AbstractDefinition> tableDefinitionMap,
                                             Map<String, AbstractDefinition> windowDefinitionMap,
                                             Map<String, AbstractDefinition> aggregationDefinitionMap,
-                                            MetaStreamEvent metaStreamEvent) {
+                                            boolean multiValue, MetaStreamEvent metaStreamEvent) {
         String streamId = inputStream.getStreamId();
 
         if (!inputStream.isInnerStream() && windowDefinitionMap != null && windowDefinitionMap.containsKey(streamId)) {
@@ -288,6 +291,7 @@ public class SingleInputStreamParser {
                 !(inputStream.getStreamId()).equals(inputStream.getStreamReferenceId())) { //if ref id is provided
             metaStreamEvent.setInputReferenceId(inputStream.getStreamReferenceId());
         }
+        metaStreamEvent.setMultiValue(multiValue);
     }
 
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/StateInputStreamParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/StateInputStreamParser.java
@@ -116,8 +116,8 @@ public class StateInputStreamParser {
                 windowDefinitionMap, aggregationDefinitionMap, tableMap, metaStateEvent,
                 variableExpressionExecutors, processStreamReceiverMap,
                 null, null,
-                stateInputStream.getStateType(),
-                preStateProcessors, true, startupPreStateProcessors, siddhiQueryContext);
+                stateInputStream.getStateType(), false, preStateProcessors, true,
+                startupPreStateProcessors, siddhiQueryContext);
 
         stateStreamRuntime.setInnerStateRuntime(innerStateRuntime);
         stateStreamRuntime.setStartupPreStateProcessors(startupPreStateProcessors);
@@ -153,6 +153,7 @@ public class StateInputStreamParser {
                                            StreamPreStateProcessor streamPreStateProcessor,
                                            StreamPostStateProcessor streamPostStateProcessor,
                                            StateInputStream.Type stateType,
+                                           boolean multiValue,
                                            List<PreStateProcessor> preStateProcessors,
                                            boolean isStartState,
                                            List<PreStateProcessor> startupPreStateProcessors,
@@ -167,7 +168,8 @@ public class StateInputStreamParser {
                     basicSingleInputStream, variableExpressionExecutors, streamDefinitionMap,
                     tableDefinitionMap, windowDefinitionMap, aggregationDefinitionMap, tableMap, metaStateEvent,
                     processStreamReceiverMap.get(basicSingleInputStream.getUniqueStreamIds().get(0)),
-                    false, false, false, siddhiQueryContext);
+                    false, false, false, multiValue,
+                    siddhiQueryContext);
 
             int stateIndex = metaStateEvent.getStreamEventCount() - 1;
             if (streamPreStateProcessor == null) {
@@ -225,14 +227,14 @@ public class StateInputStreamParser {
                     tableDefinitionMap, windowDefinitionMap, aggregationDefinitionMap, tableMap, metaStateEvent,
                     variableExpressionExecutors,
                     processStreamReceiverMap,
-                    streamPreStateProcessor, streamPostStateProcessor,
-                    stateType, preStateProcessors, isStartState, startupPreStateProcessors, siddhiQueryContext);
+                    streamPreStateProcessor, streamPostStateProcessor, stateType, multiValue,
+                    preStateProcessors, isStartState, startupPreStateProcessors, siddhiQueryContext);
 
             StateElement nextElement = ((NextStateElement) stateElement).getNextStateElement();
             InnerStateRuntime nextInnerStateRuntime = parse(nextElement, streamDefinitionMap, tableDefinitionMap,
                     windowDefinitionMap, aggregationDefinitionMap, tableMap, metaStateEvent,
                     variableExpressionExecutors, processStreamReceiverMap,
-                    streamPreStateProcessor, streamPostStateProcessor, stateType, preStateProcessors,
+                    streamPreStateProcessor, streamPostStateProcessor, stateType, multiValue, preStateProcessors,
                     false, startupPreStateProcessors, siddhiQueryContext);
 
             currentInnerStateRuntime.getLastProcessor().setNextStatePreProcessor(nextInnerStateRuntime
@@ -260,7 +262,7 @@ public class StateInputStreamParser {
             InnerStateRuntime innerStateRuntime = parse(currentElement, streamDefinitionMap, tableDefinitionMap,
                     windowDefinitionMap, aggregationDefinitionMap, tableMap, metaStateEvent,
                     variableExpressionExecutors, processStreamReceiverMap,
-                    streamPreStateProcessor, streamPostStateProcessor, stateType,
+                    streamPreStateProcessor, streamPostStateProcessor, stateType, multiValue,
                     withinEveryPreStateProcessors, isStartState, startupPreStateProcessors, siddhiQueryContext);
 
             EveryInnerStateRuntime everyInnerStateRuntime = new EveryInnerStateRuntime(innerStateRuntime, stateType);
@@ -344,14 +346,14 @@ public class StateInputStreamParser {
             InnerStateRuntime innerStateRuntime2 = parse(stateElement2, streamDefinitionMap, tableDefinitionMap,
                     windowDefinitionMap, aggregationDefinitionMap, tableMap, metaStateEvent,
                     variableExpressionExecutors, processStreamReceiverMap,
-                    logicalPreStateProcessor2, logicalPostStateProcessor2,
-                    stateType, preStateProcessors, isStartState, startupPreStateProcessors, siddhiQueryContext);
+                    logicalPreStateProcessor2, logicalPostStateProcessor2, stateType, multiValue,
+                    preStateProcessors, isStartState, startupPreStateProcessors, siddhiQueryContext);
 
             StateElement stateElement1 = ((LogicalStateElement) stateElement).getStreamStateElement1();
             InnerStateRuntime innerStateRuntime1 = parse(stateElement1, streamDefinitionMap, tableDefinitionMap,
                     windowDefinitionMap, aggregationDefinitionMap, tableMap, metaStateEvent,
                     variableExpressionExecutors, processStreamReceiverMap,
-                    logicalPreStateProcessor1, logicalPostStateProcessor1, stateType,
+                    logicalPreStateProcessor1, logicalPostStateProcessor1, stateType, multiValue,
                     preStateProcessors, isStartState, startupPreStateProcessors, siddhiQueryContext);
 
 
@@ -391,7 +393,7 @@ public class StateInputStreamParser {
             InnerStateRuntime innerStateRuntime = parse(currentElement, streamDefinitionMap, tableDefinitionMap,
                     windowDefinitionMap, aggregationDefinitionMap, tableMap, metaStateEvent,
                     variableExpressionExecutors, processStreamReceiverMap,
-                    countPreStateProcessor, countPostStateProcessor, stateType,
+                    countPreStateProcessor, countPostStateProcessor, stateType, true,
                     preStateProcessors, isStartState, startupPreStateProcessors, siddhiQueryContext);
 
             return new CountInnerStateRuntime((StreamInnerStateRuntime) innerStateRuntime);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/persistence/util/IncrementalSnapshotInfo.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/persistence/util/IncrementalSnapshotInfo.java
@@ -18,6 +18,8 @@
 
 package io.siddhi.core.util.persistence.util;
 
+import io.siddhi.core.util.SiddhiConstants;
+
 /**
  * Struct to store information about Incremental Snapshot
  */
@@ -42,17 +44,19 @@ public class IncrementalSnapshotInfo {
         this.time = time;
         this.type = type;
         this.partitionGroupByKey = partitionGroupByKey;
-        this.id = siddhiAppId +
+        this.id = (siddhiAppId +
                 PersistenceConstants.REVISION_SEPARATOR + partitionId +
                 PersistenceConstants.REVISION_SEPARATOR + partitionGroupByKey +
                 PersistenceConstants.REVISION_SEPARATOR + queryName +
-                PersistenceConstants.REVISION_SEPARATOR + elementId;
-        this.revision = time + PersistenceConstants.REVISION_SEPARATOR + siddhiAppId +
+                PersistenceConstants.REVISION_SEPARATOR + elementId).
+                replaceAll(SiddhiConstants.KEY_DELIMITER, SiddhiConstants.KEY_DELIMITER_FILE);
+        this.revision = (time + PersistenceConstants.REVISION_SEPARATOR + siddhiAppId +
                 PersistenceConstants.REVISION_SEPARATOR + partitionId +
                 PersistenceConstants.REVISION_SEPARATOR + partitionGroupByKey +
                 PersistenceConstants.REVISION_SEPARATOR + queryName +
                 PersistenceConstants.REVISION_SEPARATOR + elementId +
-                PersistenceConstants.REVISION_SEPARATOR + type;
+                PersistenceConstants.REVISION_SEPARATOR + type).
+                replaceAll(SiddhiConstants.KEY_DELIMITER, SiddhiConstants.KEY_DELIMITER_FILE);
     }
 
     public String getSiddhiAppId() {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/persistence/util/PersistenceHelper.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/persistence/util/PersistenceHelper.java
@@ -20,6 +20,7 @@ package io.siddhi.core.util.persistence.util;
 
 import io.siddhi.core.config.SiddhiAppContext;
 import io.siddhi.core.exception.PersistenceStoreException;
+import io.siddhi.core.util.SiddhiConstants;
 import io.siddhi.core.util.snapshot.AsyncIncrementalSnapshotPersistor;
 import io.siddhi.core.util.snapshot.AsyncSnapshotPersistor;
 import io.siddhi.core.util.snapshot.IncrementalSnapshot;
@@ -36,7 +37,8 @@ import java.util.concurrent.Future;
 public final class PersistenceHelper {
 
     public static IncrementalSnapshotInfo convertRevision(String revision) {
-        String[] items = revision.split(PersistenceConstants.REVISION_SEPARATOR);
+        String[] items = revision.replaceAll(SiddhiConstants.KEY_DELIMITER_FILE, SiddhiConstants.KEY_DELIMITER).
+                split(PersistenceConstants.REVISION_SEPARATOR);
         //Note: Here we discard the (items.length == 2) scenario which is handled by the full snapshot handling
         if (items.length == 7) {
             return new IncrementalSnapshotInfo(items[1], items[2], items[4], items[5],

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/pattern/absent/LogicalAbsentPatternTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/pattern/absent/LogicalAbsentPatternTestCase.java
@@ -1257,7 +1257,7 @@ public class LogicalAbsentPatternTestCase {
         siddhiAppRuntime.start();
 
         stream1.send(new Object[]{"WSO2", 15.0f, 100});
-        Thread.sleep(1100);
+        Thread.sleep(1200);
 
         callback.throwAssertionErrors();
         AssertJUnit.assertEquals("Number of success events", 1, callback.getInEventCount());


### PR DESCRIPTION
## Purpose
> Currently there is no way of retrieving the all the events that are collected by the counting-pattern, currently we can only access the events via their indexes. 
> Fixes https://github.com/siddhi-io/siddhi/issues/1398

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> When counting patterns are used such as `e1=StockStream<2:8>` and when they are referred without indexes such as `e1.price` it collects the price values from all the events in the counting pattern `e1` and produce it as a list. Since the list is not native to Siddhi the attribute will have `object` as its type.

## Release note
> Support outputting the events collected in counting-pattern as a list 

## Documentation
> When a counting pattern is referred without indexes such as `e1.x` all the values of `x` from all the collected events in the counting pattern `e1` and outputted as a list. Since the list is not natively supported in Siddhi this attribute will have `object` as its type.

