### PR TITLE
 Fix TimeBatchWindow with streaming output, processing events in batches.

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/processor/stream/LogStreamProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/processor/stream/LogStreamProcessor.java
@@ -52,7 +52,7 @@ import java.util.List;
 @Extension(
         name = "log",
         namespace = "",
-        description = "The logger logs the message on the given priority with or without processed event.",
+        description = "Logs the message on the given priority with or without the processed event.",
         parameters = {
                 @Parameter(name = "priority",
                         description = "The priority/type of this log message (INFO, DEBUG, WARN," +
@@ -79,40 +79,40 @@ import java.util.List;
         },
         examples = {
                 @Example(
-                        syntax = "from fooStream#log(\"INFO\", \"Sample Event :\", true)\n" +
+                        syntax = "from FooStream#log(\"INFO\", \"Sample Event :\", true)\n" +
                                 "select *\n" +
-                                "insert into barStream;",
-                        description = "This will log as INFO with the message \"Sample Event :\" + fooStream:events."
+                                "insert into FooStream;",
+                        description = "This will log as INFO with the message \"Sample Event :\" + FooStream:events."
                 ),
                 @Example(
-                        syntax = "from fooStream#log(\"Sample Event :\", true)\n" +
+                        syntax = "from FooStream#log(\"Sample Event :\", true)\n" +
                                 "select *\n" +
-                                "insert into barStream;",
+                                "insert into FooStream;",
                         description = "This will logs with default log level as INFO."
                 ),
                 @Example(
-                        syntax = "from fooStream#log(\"Sample Event :\", fasle)\n" +
+                        syntax = "from FooStream#log(\"Sample Event :\", fasle)\n" +
                                 "select *\n" +
-                                "insert into barStream;",
+                                "insert into FooStream;",
                         description = "This will only log message."
                 ),
                 @Example(
-                        syntax = "from fooStream#log(true)\n" +
+                        syntax = "from FooStream#log(true)\n" +
                                 "select *\n" +
-                                "insert into barStream;",
-                        description = "This will only log fooStream:events."
+                                "insert into FooStream;",
+                        description = "This will only log FooStream:events."
                 ),
                 @Example(
-                        syntax = "from fooStream#log()\n" +
+                        syntax = "from FooStream#log()\n" +
                                 "select *\n" +
-                                "insert into barStream;",
-                        description = "This will only log fooStream:events."
+                                "insert into FooStream;",
+                        description = "This will only log FooStream:events."
                 ),
                 @Example(
-                        syntax = "from fooStream#log(\"Sample Event :\")\n" +
+                        syntax = "from FooStream#log(\"Sample Event :\")\n" +
                                 "select *\n" +
-                                "insert into barStream;",
-                        description = "This will log message and fooStream:events."
+                                "insert into FooStream;",
+                        description = "This will log message and FooStream:events."
                 )
         }
 )

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/processor/stream/window/TimeBatchWindowProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/processor/stream/window/TimeBatchWindowProcessor.java
@@ -33,6 +33,7 @@ import io.siddhi.core.event.stream.holder.StreamEventClonerHolder;
 import io.siddhi.core.executor.ConstantExpressionExecutor;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.VariableExpressionExecutor;
+import io.siddhi.core.query.processor.ProcessingMode;
 import io.siddhi.core.query.processor.Processor;
 import io.siddhi.core.query.processor.SchedulingProcessor;
 import io.siddhi.core.table.Table;
@@ -227,6 +228,16 @@ public class TimeBatchWindowProcessor extends BatchingFindableWindowProcessor<Ti
         return () -> new WindowState(streamEventClonerHolder, outputExpectsExpiredEvents, findToBeExecuted);
 
     }
+
+    @Override
+    public ProcessingMode getProcessingMode() {
+        if (isStreamCurrentEvents) {
+            return ProcessingMode.SLIDE;
+        } else {
+            return ProcessingMode.BATCH;
+        }
+    }
+
 
     private void initTimeParameter(ExpressionExecutor attributeExpressionExecutor) {
         if (attributeExpressionExecutor instanceof ConstantExpressionExecutor) {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/InMemorySource.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/InMemorySource.java
@@ -39,20 +39,24 @@ import org.apache.log4j.Logger;
 @Extension(
         name = "inMemory",
         namespace = "source",
-        description = "In-memory source that can communicate with other in-memory sinks within the same JVM, it " +
-                "is assumed that the publisher and subscriber of a topic uses same event schema (stream definition).",
-        parameters = @Parameter(name = "topic", type = DataType.STRING, description = "Subscribes to sent on the "
-                + "given topic."),
+        description = "In-memory source subscribes to a topic to consume events which are published on the " +
+                "same topic by In-memory sinks. " +
+                "This provides a way to connect multiple Siddhi Apps deployed under the same Siddhi Manager (JVM). " +
+                "Here both the publisher and subscriber should have the same event schema (stream definition) " +
+                "for successful data transfer.",
+        parameters = @Parameter(name = "topic", type = DataType.STRING,
+                description = "Subscribes to the events sent on the given topic."),
         parameterOverloads = {
                 @ParameterOverload(parameterNames = {"topic"})
         },
         examples = @Example(
-                syntax = "@source(type='inMemory', @map(type='passThrough'))\n" +
-                        "define stream BarStream (symbol string, price float, volume long)",
-                description = "In this example BarStream uses inMemory transport which passes the received event " +
-                        "internally without using external transport."
+                syntax = "@source(type='inMemory', topic='Stocks', @map(type='passThrough'))\n" +
+                        "define stream StocksStream (symbol string, price float, volume long);",
+                description = "Here the `StocksStream` uses inMemory source to consume events published " +
+                        "on the topic `Stocks` by the inMemory sinks deployed in the same JVM."
         )
 )
+
 public class InMemorySource extends Source {
     private static final Logger LOG = Logger.getLogger(InMemorySource.class);
     private static final String TOPIC_KEY = "topic";

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/InMemorySink.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/InMemorySink.java
@@ -44,19 +44,21 @@ import org.apache.log4j.Logger;
 @Extension(
         name = "inMemory",
         namespace = "sink",
-        description = "In-memory transport that can communicate with other in-memory transports within the same JVM, " +
-                "it" +
-                "is assumed that the publisher and subscriber of a topic uses same event schema (stream definition).",
-        parameters = @Parameter(name = "topic", type = DataType.STRING, description = "Event will be delivered to all" +
-                "the subscribers of the same topic"),
+        description = "In-memory sink publishes events to In-memory sources that are subscribe to the same topic " +
+                "to which the sink publishes. This provides a way to connect multiple Siddhi Apps deployed " +
+                "under the same Siddhi Manager (JVM). " +
+                "Here both the publisher and subscriber should have the same event schema (stream definition) " +
+                "for successful data transfer.",
+        parameters = @Parameter(name = "topic", type = DataType.STRING, description = "Event are delivered to all" +
+                "the subscribers subscribed on this topic."),
         parameterOverloads = {
                 @ParameterOverload(parameterNames = {"topic"})
         },
         examples = @Example(
-                syntax = "@sink(type='inMemory', @map(type='passThrough'))\n" +
-                        "define stream BarStream (symbol string, price float, volume long)",
-                description = "In this example BarStream uses inMemory transport which emit the Siddhi " +
-                        "events internally without using external transport and transformation."
+                syntax = "@sink(type='inMemory', topic='Stocks', @map(type='passThrough'))\n" +
+                        "define stream StocksStream (symbol string, price float, volume long);",
+                description = "Here the `StocksStream` uses inMemory sink to emit the Siddhi events to all " +
+                        "the inMemory sources deployed in the same JVM and subscribed to the topic `Stocks`."
         )
 )
 public class InMemorySink extends Sink<State> {


### PR DESCRIPTION
## Purpose
> To effectively implement throttling use cases with alert suppression. 
> Also improve documentation of in-memory sink, in-memory source, and log stream processor. 

## Release note
>  Fixes to TimeBatchWindow to process events in a streaming manner, when it's enabled to send current events in streaming mode. This makes sure all having conditions are matched against the output, whereby allowing users to effectively implement throttling use cases with alert suppression. 