### PR TITLE
Revert "Bump slf4j.version from 1.7.12 to 1.7.26"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -746,7 +746,7 @@
         <testng.version>6.14.3</testng.version>
         <log4j.version>1.2.17</log4j.version>
         <log4j.imp.pkg.version.range>[1.2.17, 1.3.0)</log4j.imp.pkg.version.range>
-        <slf4j.version>1.7.26</slf4j.version>
+        <slf4j.version>1.7.12</slf4j.version>
         <mvel2.version>2.4.4.Final</mvel2.version>
         <antlr.runtime.version>4.7.2</antlr.runtime.version>
         <disruptor.version>3.4.2.wso2v1</disruptor.version>


### PR DESCRIPTION
Reverts siddhi-io/siddhi#1432
> This is to avoid version compatibility issues (with dependencies) when creating the Siddhi distribution. 

 