### PR TITLE
Add YAMLConfigManager support

### DIFF
--- a/modules/siddhi-core/pom.xml
+++ b/modules/siddhi-core/pom.xml
@@ -94,6 +94,10 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/exception/YAMLConfigManagerException.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/exception/YAMLConfigManagerException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.exception;
+
+/**
+ * Exception class to be used when non-existence definition is requested.
+ */
+public class YAMLConfigManagerException extends RuntimeException {
+
+    public YAMLConfigManagerException() {
+        super();
+    }
+
+    public YAMLConfigManagerException(String message) {
+        super(message);
+    }
+
+    public YAMLConfigManagerException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
+    public YAMLConfigManagerException(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/FileReader.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/FileReader.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.util;
+
+import io.siddhi.core.exception.YAMLConfigManagerException;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Util class to read file content
+ */
+public class FileReader {
+
+    private static final Logger LOG = Logger.getLogger(FileReader.class);
+
+    public static String readYAMLConfigFile(Path filePath) throws YAMLConfigManagerException {
+        if (!filePath.toFile().exists()) {
+            throw new YAMLConfigManagerException("Error while initializing YAML config manager, " +
+                    "YAML file does not exist with path '" + filePath.toAbsolutePath().toString() + "'.");
+        }
+        if (!filePath.toString().endsWith(".yaml")) {
+            throw new YAMLConfigManagerException("Error while initializing YAML config manager, file extension " +
+                    "'yaml' expected");
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("initialize config provider instance from configuration file: " + filePath.toString());
+        }
+        try {
+            return readContent(filePath);
+        } catch (IOException e) {
+            throw new YAMLConfigManagerException("Unable to read config file '" + filePath.toAbsolutePath().toString()
+                    + "'.", e);
+        }
+    }
+
+    private static String readContent(Path filePath) throws IOException {
+        byte[] contentBytes = Files.readAllBytes(filePath);
+        return new String(contentBytes, StandardCharsets.UTF_8);
+    }
+
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/FileReader.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/FileReader.java
@@ -43,7 +43,7 @@ public class FileReader {
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("initialize config provider instance from configuration file: " + filePath.toString());
+            LOG.debug("Initialize config provider instance from configuration file: " + filePath.toString());
         }
         try {
             return readContent(filePath);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/ConfigManager.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/ConfigManager.java
@@ -25,9 +25,28 @@ import java.util.Map;
  */
 public interface ConfigManager {
 
+    /**
+     * Generates Config reader for extensions with specific namespace and name
+     *
+     * @param namespace Namespace of the extension
+     * @param name Name of the extension
+     * @return ConfigReader
+     */
     ConfigReader generateConfigReader(String namespace, String name);
 
+    /**
+     * Generates hash map of properties for siddhi annotation reference
+     *
+     * @param name Reference Name
+     * @return Hashmap of the properties
+     */
     Map<String, String> extractSystemConfigs(String name);
 
+    /**
+     * Extracts specific siddhi property in system properties
+     *
+     * @param name Name of the property
+     * @return Value of the property
+     */
     String extractProperty(String name);
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/ConfigReader.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/ConfigReader.java
@@ -25,8 +25,19 @@ import java.util.Map;
  */
 public interface ConfigReader {
 
+    /**
+     * Returns the value of the system property if set else the default value is returned
+     *
+     * @param name Name of the property
+     * @param defaultValue Default value for the property
+     * @return Value of the system property
+     */
     String readConfig(String name, String defaultValue);
 
+    /**
+     * Return all the configurations in the config reader
+     * @return Hashmap of properties and values
+     */
     Map<String, String> getAllConfigs();
 
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/YAMLConfigManager.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/YAMLConfigManager.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.util.config;
+
+import io.siddhi.core.exception.YAMLConfigManagerException;
+import io.siddhi.core.util.SiddhiConstants;
+import io.siddhi.core.util.config.model.Extension;
+import io.siddhi.core.util.config.model.ExtensionChildConfiguration;
+import io.siddhi.core.util.config.model.Reference;
+import io.siddhi.core.util.config.model.ReferenceChildConfiguration;
+import io.siddhi.core.util.config.model.RootConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
+import org.yaml.snakeyaml.introspector.BeanAccess;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * YAML file based Config Manger
+ */
+public class YAMLConfigManager implements ConfigManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(YAMLConfigManager.class);
+    private String filePathName;
+    private RootConfiguration rootConfiguration;
+
+    public YAMLConfigManager(String filePath) {
+        this.filePathName = filePath;
+    }
+
+    /**
+     * Initialises YAML Config Manager by parsing the YAML file
+     *
+     * @throws YAMLConfigManagerException Exception is thrown if there are issues in processing thr yaml file
+     */
+    public void init() throws YAMLConfigManagerException {
+
+        Path filePath = Paths.get(this.filePathName);
+        if (!filePath.toFile().exists()) {
+            throw new YAMLConfigManagerException("Error while initializing YAML config manager, " +
+                    "YAML file does not exist with path '" + filePath.toAbsolutePath().toString() + "'.");
+        }
+        if (!filePath.toString().endsWith(".yaml")) {
+            throw new YAMLConfigManagerException("Error while initializing YAML config manager, file extension " +
+                    "'yaml' expected");
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("initialize config provider instance from configuration file: " + filePath.toString());
+        }
+
+        String fileContent;
+        try {
+            byte[] contentBytes = Files.readAllBytes(filePath);
+            fileContent = new String(contentBytes, StandardCharsets.UTF_8);
+            Yaml yaml = new Yaml(new CustomClassLoaderConstructor(
+                    RootConfiguration.class, RootConfiguration.class.getClassLoader()));
+            yaml.setBeanAccess(BeanAccess.FIELD);
+            this.rootConfiguration = yaml.load(fileContent);
+        } catch (IOException e) {
+           throw new YAMLConfigManagerException("Unable read YAML file content of path '" +
+                   filePath.toAbsolutePath().toString() + "'.", e);
+        } catch (Exception e1) {
+            throw new YAMLConfigManagerException("Unable to parse YAML file content of path '" +
+                    filePath.toAbsolutePath().toString() + "'.", e1);
+        }
+    }
+
+    @Override
+    public ConfigReader generateConfigReader(String namespace, String name) {
+        for (Extension extension : this.rootConfiguration.getExtensions()) {
+            ExtensionChildConfiguration childConfiguration = extension.getExtension();
+            if (childConfiguration.getNamespace().equals(namespace) &&
+                    childConfiguration.getName().equals(name)) {
+                return new YAMLConfigReader(childConfiguration.getProperties());
+            }
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Could not find a matching configuration for name: " + name + "and namespace: " +
+                    namespace + "!");
+        }
+        return new YAMLConfigReader(new HashMap<>());
+    }
+
+    @Override
+    public Map<String, String> extractSystemConfigs(String name) {
+        for (Reference reference : this.rootConfiguration.getRefs()) {
+            ReferenceChildConfiguration childConf = reference.getReference();
+            if (childConf.getName().equals(name)) {
+                Map<String, String> referenceConfigs = new HashMap<>();
+                referenceConfigs.put(SiddhiConstants.ANNOTATION_ELEMENT_TYPE, childConf.getType());
+                referenceConfigs.putAll(childConf.getProperties());
+                return referenceConfigs;
+            }
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Could not find a matching reference for name: '" + name + "'!");
+        }
+        return new HashMap<>();
+    }
+
+    @Override
+    public String extractProperty(String name) {
+        String property = this.rootConfiguration.getProperties().get(name);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Could not find a matching configuration for property name: " + name + "");
+        }
+        return property;
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/YAMLConfigReader.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/YAMLConfigReader.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.util.config;
+
+import java.util.Map;
+
+/**
+ * Extension config readers
+ */
+public class YAMLConfigReader implements ConfigReader {
+    private final Map<String, String> configs;
+
+    public YAMLConfigReader(Map<String, String> configs) {
+        this.configs = configs;
+    }
+
+    @Override
+    public String readConfig(String name, String defaultValue) {
+        String value = configs.get(name);
+        if (value != null) {
+            return value;
+        } else {
+            return defaultValue;
+        }
+    }
+
+    @Override
+    public Map<String, String> getAllConfigs() {
+        return configs;
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/model/Extension.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/model/Extension.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.util.config.model;
+
+/**
+ * A third level configuration bean class for siddhi extension config.
+ */
+public class Extension {
+
+    private ExtensionChildConfiguration extension = new ExtensionChildConfiguration();
+
+    public ExtensionChildConfiguration getExtension() {
+        return extension;
+    }
+}
+

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/model/ExtensionChildConfiguration.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/model/ExtensionChildConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.util.config.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A second level configuration bean class for siddhi extension config.
+ */
+public class ExtensionChildConfiguration {
+
+    private String name = "";
+    private String namespace = "";
+    private Map<String, String> properties = new HashMap<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public String toString() {
+        return "name : " + name + ", namespace : " + namespace + ", properties : " + properties.toString();
+    }
+}
+

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/model/Reference.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/model/Reference.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.util.config.model;
+
+/**
+ * A third level configuration bean class for siddhi reference config.
+ */
+public class Reference {
+
+    private ReferenceChildConfiguration ref = new ReferenceChildConfiguration();
+
+    public ReferenceChildConfiguration getReference() {
+        return ref;
+    }
+
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/model/ReferenceChildConfiguration.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/model/ReferenceChildConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.util.config.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A second level configuration bean class for siddhi reference config.
+ */
+public class ReferenceChildConfiguration {
+
+    private String name = "";
+    private String type = "";
+    private Map<String, String> properties = new HashMap<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public String toString() {
+        return "name : " + name + ", properties : " + properties.toString();
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/model/RootConfiguration.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/model/RootConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.util.config.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@code RootConfiguration} is a bean class for root level configuration.
+ */
+public class RootConfiguration {
+
+    private List<Extension> extensions;
+    private List<Reference> refs;
+    private Map<String, String> properties;
+
+    public RootConfiguration() {
+        this.extensions = new ArrayList<>();
+        this.refs = new ArrayList<>();
+        this.properties = new HashMap<>();
+    }
+
+    public List<Extension> getExtensions() {
+        return extensions;
+    }
+
+    public List<Reference> getRefs() {
+        return refs;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+}

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/config/YAMLConfigManagerTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/config/YAMLConfigManagerTestCase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.config;
+
+import io.siddhi.core.util.config.ConfigReader;
+import io.siddhi.core.util.config.YAMLConfigManager;
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class YAMLConfigManagerTestCase {
+    private static final Logger log = Logger.getLogger(YAMLConfigManagerTestCase.class);
+
+    @Test
+    public void yamlConfigManagerTest1() {
+        log.info("YAMLConfigManagerTest1");
+
+        String baseDir = Paths.get(".").toString();
+        Path path = Paths.get(baseDir, "src", "test", "resources", "systemProperties.yaml");
+
+        YAMLConfigManager yamlConfigManager = new YAMLConfigManager(path.toAbsolutePath().toString());
+        yamlConfigManager.init();
+
+        Map<String, String> testConfigs = yamlConfigManager.extractSystemConfigs("test");
+        Assert.assertEquals(testConfigs.size(), 0);
+
+        Map<String, String> source1Ref = yamlConfigManager.extractSystemConfigs("source1");
+        Assert.assertEquals(source1Ref.size(), 3);
+        Assert.assertEquals(source1Ref.get("type"), "source-type");
+        Assert.assertEquals(source1Ref.get("property1"), "value1");
+        Assert.assertEquals(source1Ref.get("property2"), "value2");
+        Assert.assertNull(source1Ref.get("property3"));
+
+        String partitionById = yamlConfigManager.extractProperty("partitionById");
+        Assert.assertEquals(partitionById, "TRUE");
+
+        String shardID1 = yamlConfigManager.extractProperty("shardId1");
+        Assert.assertNull(shardID1);
+
+        ConfigReader testConfigReader = yamlConfigManager.generateConfigReader("test", "test");
+        Assert.assertEquals(testConfigReader.getAllConfigs().size(), 0);
+
+        ConfigReader configReader = yamlConfigManager.generateConfigReader("store", "rdbms");
+        Assert.assertEquals(configReader.getAllConfigs().size(), 5);
+        Assert.assertEquals(configReader.readConfig("mysql.batchEnable", "test"), "true");
+        Assert.assertEquals(configReader.readConfig("test", "test"), "test");
+
+    }
+}

--- a/modules/siddhi-core/src/test/resources/systemProperties.yaml
+++ b/modules/siddhi-core/src/test/resources/systemProperties.yaml
@@ -1,0 +1,25 @@
+# Siddhi related properties
+properties:
+  partitionById: TRUE
+  shardId: shard1
+
+# Siddhi references
+refs:
+  - ref:
+      type: source-type
+      name: source1
+      properties:
+        property1: value1
+        property2: value2
+
+# Siddi Extensions system Parameters
+extensions:
+  - extension:
+      name: rdbms
+      namespace: store
+      properties:
+        mysql.batchEnable: true
+        mysql.batchSize: 1000
+        mysql.indexCreateQuery: "CREATE INDEX {{TABLE_NAME}}_INDEX ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})"
+        mysql.recordDeleteQuery: "DELETE FROM {{TABLE_NAME}} {{CONDITION}}"
+        mysql.recordExistsQuery: "SELECT 1 FROM {{TABLE_NAME}} {{CONDITION}} LIMIT 1"

--- a/modules/siddhi-core/src/test/resources/systemProperties.yaml
+++ b/modules/siddhi-core/src/test/resources/systemProperties.yaml
@@ -6,13 +6,13 @@ properties:
 # Siddhi references
 refs:
   - ref:
-      type: testStoreContainingInMemoryTable
       name: ref1
+      type: testStoreContainingInMemoryTable
       properties:
         property1: value1
         property2: value2
 
-# Siddi Extensions system Parameters
+# Siddhi Extensions system Parameters
 extensions:
   - extension:
       name: rdbms
@@ -23,3 +23,12 @@ extensions:
         mysql.indexCreateQuery: "CREATE INDEX {{TABLE_NAME}}_INDEX ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})"
         mysql.recordDeleteQuery: "DELETE FROM {{TABLE_NAME}} {{CONDITION}}"
         mysql.recordExistsQuery: "SELECT 1 FROM {{TABLE_NAME}} {{CONDITION}} LIMIT 1"
+  - extension:
+      name: getAllNew
+      namespace: email
+      properties:
+        append.abc: true
+
+## Test to see if the additional properties are ignored
+test:
+  test1: yes

--- a/modules/siddhi-core/src/test/resources/systemProperties.yaml
+++ b/modules/siddhi-core/src/test/resources/systemProperties.yaml
@@ -6,8 +6,8 @@ properties:
 # Siddhi references
 refs:
   - ref:
-      type: source-type
-      name: source1
+      type: testStoreContainingInMemoryTable
+      name: ref1
       properties:
         property1: value1
         property2: value2

--- a/modules/siddhi-core/src/test/resources/testng.xml
+++ b/modules/siddhi-core/src/test/resources/testng.xml
@@ -184,6 +184,9 @@
             <class name="io.siddhi.core.query.table.teststorecontaininginmemorytable.QueryAPITestCaseForTestStore"/>
             <class name="io.siddhi.core.query.table.teststorecontaininginmemorytable.UpdateOrInsertTestStoreTestCase"/>
             <class name="io.siddhi.core.query.table.teststorecontaininginmemorytable.UpdateTestStoreTestCase"/>
+
+            <class name="io.siddhi.core.config.YAMLConfigManagerTestCase"/>
+
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
$subject fixes https://github.com/siddhi-io/siddhi/issues/1445

## Goals
To support YAML Config Manager for easy setting of system properties in SiddhiManager

## Approach
As in f3c8ea2

## Release note
Add support YAML Config Manager for easy setting of system properties in SiddhiManager through a YAML file

## Automation tests
 - Unit tests - Attached herewith
 - Integration tests - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
1.8.0_191 
