### PR TITLE
Add log/wait/fault-stream support for asynchronous event sinks

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/input/stream/state/AbsentLogicalPreStateProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/input/stream/state/AbsentLogicalPreStateProcessor.java
@@ -182,6 +182,7 @@ public class AbsentLogicalPreStateProcessor extends LogicalPreStateProcessor imp
                     while (retEventChunk.hasNext()) {
                         StateEvent stateEvent = retEventChunk.next();
                         retEventChunk.remove();
+                        stateEvent.setTimestamp(currentTime);
                         sendEvent(stateEvent, state);
                     }
                     ((LogicalStreamPreState) state).lastArrivalTime = 0;

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/input/stream/state/StreamPreStateProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/input/stream/state/StreamPreStateProcessor.java
@@ -66,6 +66,15 @@ public class StreamPreStateProcessor implements PreStateProcessor {
     protected Comparator eventTimeComparator = new Comparator<StateEvent>() {
         @Override
         public int compare(StateEvent o1, StateEvent o2) {
+            if (o1.getTimestamp() == -1) {
+                if (o2.getTimestamp() == -1) {
+                    return 0;
+                } else {
+                    return 1;
+                }
+            } else if (o2.getTimestamp() == -1) {
+                return -1;
+            }
             return Long.compare(o1.getTimestamp(), o2.getTimestamp());
         }
     };

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/InMemorySink.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/InMemorySink.java
@@ -108,7 +108,7 @@ public class InMemorySink extends Sink<State> {
         try {
             InMemoryBroker.publish(topicOption.getValue(dynamicOptions), payload);
         } catch (SubscriberUnAvailableException e) {
-            onError(payload, e);
+            onError(payload, dynamicOptions, new ConnectionUnavailableException(e.getMessage(), e));
         }
     }
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/SinkMapper.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/SinkMapper.java
@@ -51,18 +51,19 @@ public abstract class SinkMapper {
     private ThreadLocal<DynamicOptions> trpDynamicOptions = new ThreadLocal<>();
     private LatencyTracker mapperLatencyTracker;
     private SiddhiAppContext siddhiAppContext;
+    protected String sinkType;
+    protected OptionHolder sinkOptionHolder;
 
-    public final void init(StreamDefinition streamDefinition,
-                           String type,
-                           OptionHolder mapOptionHolder,
-                           List<Element> unmappedPayloadList,
-                           Sink sink, ConfigReader mapperConfigReader,
-                           LatencyTracker mapperLatencyTracker,
+    public final void init(StreamDefinition streamDefinition, String type, OptionHolder mapOptionHolder,
+                           List<Element> unmappedPayloadList, Sink sink, ConfigReader mapperConfigReader,
+                           LatencyTracker mapperLatencyTracker, OptionHolder sinkOptionHolder,
                            SiddhiAppContext siddhiAppContext) {
         this.mapperLatencyTracker = mapperLatencyTracker;
         this.siddhiAppContext = siddhiAppContext;
         sink.setTrpDynamicOptions(trpDynamicOptions);
         this.sinkListener = sink;
+        this.sinkType = sink.getType();
+        this.sinkOptionHolder = sinkOptionHolder;
         this.optionHolder = mapOptionHolder;
         this.type = type;
         buildMapperTemplate(streamDefinition, unmappedPayloadList);
@@ -71,7 +72,8 @@ public abstract class SinkMapper {
 
     /**
      * Method to create mapper template.
-     * @param streamDefinition Stream definition corresponding to mapper
+     *
+     * @param streamDefinition    Stream definition corresponding to mapper
      * @param unmappedPayloadList mapper payload template list
      */
     protected void buildMapperTemplate(StreamDefinition streamDefinition, List<Element> unmappedPayloadList) {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/distributed/DistributedTransport.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/distributed/DistributedTransport.java
@@ -20,6 +20,7 @@ package io.siddhi.core.stream.output.sink.distributed;
 
 import io.siddhi.core.config.SiddhiAppContext;
 import io.siddhi.core.exception.ConnectionUnavailableException;
+import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.output.sink.Sink;
 import io.siddhi.core.stream.output.sink.SinkHandler;
 import io.siddhi.core.stream.output.sink.SinkMapper;
@@ -81,6 +82,7 @@ public abstract class DistributedTransport extends Sink {
      * @param sinkHandler                     Sink handler to do optional processing
      * @param payloadElementList              The template list of the payload messages
      * @param mapperConfigReader              This hold the {@link Sink} extensions configuration reader for the mapper
+     * @param streamJunction
      * @param siddhiAppContext                The siddhi app context
      * @param destinationOptionHolders        List of option holders containing the options mentioned in @destination
      * @param sinkAnnotation                  The annotation of the Sink
@@ -93,8 +95,9 @@ public abstract class DistributedTransport extends Sink {
                      ConfigReader sinkConfigReader,
                      SinkMapper sinkMapper, String mapType, OptionHolder mapOptionHolder, SinkHandler sinkHandler,
                      List<Element> payloadElementList, ConfigReader mapperConfigReader,
-                     SiddhiAppContext siddhiAppContext, List<OptionHolder> destinationOptionHolders,
-                     Annotation sinkAnnotation, DistributionStrategy strategy, String[] supportedDynamicOptions,
+                     StreamJunction streamJunction, SiddhiAppContext siddhiAppContext,
+                     List<OptionHolder> destinationOptionHolders, Annotation sinkAnnotation,
+                     DistributionStrategy strategy, String[] supportedDynamicOptions,
                      Map<String, String> deploymentProperties,
                      List<Map<String, String>> destinationDeploymentProperties) {
         this.type = type;
@@ -102,7 +105,7 @@ public abstract class DistributedTransport extends Sink {
         this.supportedDynamicOptions = supportedDynamicOptions;
         init(streamDefinition, type, transportOptionHolder, sinkConfigReader, sinkMapper, mapType, mapOptionHolder,
                 sinkHandler, payloadElementList, mapperConfigReader, new HashMap<>(),
-                siddhiAppContext);
+                streamJunction, siddhiAppContext);
         initTransport(sinkOptionHolder, destinationOptionHolders, deploymentProperties,
                 destinationDeploymentProperties, sinkAnnotation, sinkConfigReader, strategy, type, siddhiAppContext);
     }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiAppRuntimeBuilder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiAppRuntimeBuilder.java
@@ -115,7 +115,8 @@ public class SiddhiAppRuntimeBuilder {
             throw t;
         }
         DefinitionParserHelper.addEventSource(streamDefinition, sourceMap, siddhiAppContext);
-        DefinitionParserHelper.addEventSink(streamDefinition, sinkMap, siddhiAppContext);
+        StreamJunction streamJunction = streamJunctionMap.get(streamDefinition.getId());
+        DefinitionParserHelper.addEventSink(streamDefinition, streamJunction, sinkMap, siddhiAppContext);
     }
 
     public void defineTable(TableDefinition tableDefinition) {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/event/handler/StreamHandler.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/event/handler/StreamHandler.java
@@ -91,9 +91,8 @@ public class StreamHandler implements EventHandler<EventExchangeHolder> {
             case LOG:
                 for (Event event : eventBuffer) {
                     log.error("Error in SiddhiApp '" + siddhiAppName +
-                            "' after consuming events from Stream " +
-                            "'" + streamName + "', " + e.getMessage() + ". Hence, dropping event '"
-                            + event.toString() + "'", e);
+                            "' after consuming events from Stream '" + streamName + "', " + e.getMessage() +
+                            ". Hence, dropping event '" + event.toString() + "'", e);
                 }
                 break;
             case STREAM:

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/helper/DefinitionParserHelper.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/helper/DefinitionParserHelper.java
@@ -433,6 +433,7 @@ public class DefinitionParserHelper {
     }
 
     public static void addEventSink(StreamDefinition streamDefinition,
+                                    StreamJunction streamJunction,
                                     ConcurrentMap<String, List<Sink>> eventSinkMap,
                                     SiddhiAppContext siddhiAppContext) {
         for (Annotation sinkAnnotation : streamDefinition.getAnnotations()) {
@@ -541,13 +542,13 @@ public class DefinitionParserHelper {
                                 ((DistributedTransport) sink).init(streamDefinition, sinkType,
                                         transportOptionHolder, sinkConfigReader, sinkMapper,
                                         mapType, mapOptionHolder, sinkHandler, payloadElementList,
-                                        mapperConfigReader, siddhiAppContext, destinationOptHolders,
+                                        mapperConfigReader, streamJunction, siddhiAppContext, destinationOptHolders,
                                         sinkAnnotation, distributionStrategy, supportedDynamicOptions,
                                         deploymentProperties, destinationDeploymentProperties);
                             } else {
                                 sink.init(streamDefinition, sinkType, transportOptionHolder, sinkConfigReader,
                                         sinkMapper, mapType, mapOptionHolder, sinkHandler, payloadElementList,
-                                        mapperConfigReader, deploymentProperties, siddhiAppContext);
+                                        mapperConfigReader, deploymentProperties, streamJunction, siddhiAppContext);
 
                             }
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/transport/InMemoryBroker.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/transport/InMemoryBroker.java
@@ -110,7 +110,7 @@ public class InMemoryBroker {
                     subscriber.onMessage(msg);
                 }
             } else {
-                throw new SubscriberUnAvailableException("Subscriber for topic '" + topic + "' is unavailable.");
+                throw new SubscriberUnAvailableException("Subscriber for topic '" + topic + "' is unavailable");
             }
         }
 

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/pattern/absent/LogicalAbsentPatternTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/pattern/absent/LogicalAbsentPatternTestCase.java
@@ -1905,7 +1905,7 @@ public class LogicalAbsentPatternTestCase {
 
 
         callback.throwAssertionErrors();
-        AssertJUnit.assertEquals("Number of success events", 2, callback.getInEventCount());
+        AssertJUnit.assertEquals("Number of success events", 1, callback.getInEventCount());
         AssertJUnit.assertEquals("Number of remove events", 0, callback.getRemoveEventCount());
         AssertJUnit.assertTrue("Event arrived", callback.isEventArrived());
 

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/sequence/SequenceTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/sequence/SequenceTestCase.java
@@ -30,6 +30,8 @@ import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+
 /**
  * Created on 12/15/14.
  */
@@ -1214,8 +1216,7 @@ public class SequenceTestCase {
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String streams = "" +
-                "define stream Stream1 (symbol string, price float, volume int); " +
-                "define stream Stream2 (symbol string, price float, volume int); ";
+                "define stream Stream1 (symbol string, price float, volume int); ";
         String query = "" +
                 "@info(name = 'query1') " +
                 "from every e1=Stream1[price>20], " +
@@ -1254,13 +1255,11 @@ public class SequenceTestCase {
                 if (removeEvents != null) {
                     removeEventCount = removeEventCount + removeEvents.length;
                 }
-                eventArrived = true;
             }
 
         });
 
         InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
-        InputHandler stream2 = siddhiAppRuntime.getInputHandler("Stream2");
 
         siddhiAppRuntime.start();
 
@@ -1286,6 +1285,101 @@ public class SequenceTestCase {
         Thread.sleep(100);
 
         AssertJUnit.assertEquals("Number of success events", 3, inEventCount);
+        AssertJUnit.assertEquals("Number of remove events", 0, removeEventCount);
+        AssertJUnit.assertEquals("Event arrived", true, eventArrived);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testQuery20_1() throws InterruptedException {
+        log.info("testSequence20_1 - OUT 3");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream Stream1 (symbol string, price float, volume int); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from every e1=Stream1[(e1[last].price is null or e1[last].price <= price)]*, " +
+                "   e2=Stream1[price<e1[last].price] " +
+                "select e1.price as price, e2.price as lastPrice " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timestamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        switch (inEventCount) {
+                            case 1:
+                                AssertJUnit.assertEquals(Arrays.deepToString(
+                                        new Object[]{new Object[]{29.6f}, 25.0f}),
+                                        Arrays.deepToString(event.getData()));
+                                break;
+                            case 2:
+                                AssertJUnit.assertEquals(Arrays.deepToString(
+                                        new Object[]{new Object[]{25.0f, 35.6f}, 25.5f}),
+                                        Arrays.deepToString(event.getData()));
+                                break;
+                            case 3:
+                                AssertJUnit.assertEquals(Arrays.deepToString(
+                                        new Object[]{new Object[]{25.5f, 57.6f, 58.6f}, 47.6f}),
+                                        Arrays.deepToString(event.getData()));
+                                break;
+                            case 4:
+                                AssertJUnit.assertEquals(Arrays.deepToString(
+                                        new Object[]{new Object[]{47.6f}, 27.6f}),
+                                        Arrays.deepToString(event.getData()));
+                                break;
+                            case 5:
+                                AssertJUnit.assertEquals(Arrays.deepToString(
+                                        new Object[]{new Object[]{27.6f, 49.6f}, 45.6f}),
+                                        Arrays.deepToString(event.getData()));
+                                break;
+                            default:
+                                AssertJUnit.assertSame(5, inEventCount);
+                        }
+                    }
+                    eventArrived = true;
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+            }
+
+        });
+
+        InputHandler stream1 = siddhiAppRuntime.getInputHandler("Stream1");
+
+        siddhiAppRuntime.start();
+
+        stream1.send(new Object[]{"WSO2", 29.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"WSO2", 25.0f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"WSO2", 35.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"WSO2", 25.5f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"WSO2", 57.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"WSO2", 58.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"IBM", 47.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"IBM", 27.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"IBM", 49.6f, 100});
+        Thread.sleep(100);
+        stream1.send(new Object[]{"IBM", 45.6f, 100});
+        Thread.sleep(100);
+
+        AssertJUnit.assertEquals("Number of success events", 5, inEventCount);
         AssertJUnit.assertEquals("Number of remove events", 0, removeEventCount);
         AssertJUnit.assertEquals("Event arrived", true, eventArrived);
 

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/stream/FaultStreamTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/stream/FaultStreamTestCase.java
@@ -26,7 +26,9 @@ import io.siddhi.core.query.output.callback.QueryCallback;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.stream.output.StreamCallback;
 import io.siddhi.core.stream.output.sink.Sink;
+import io.siddhi.core.transport.TestAsyncInMemory;
 import io.siddhi.core.util.EventPrinter;
+import io.siddhi.core.util.transport.InMemoryBroker;
 import org.apache.log4j.Logger;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
@@ -40,6 +42,7 @@ public class FaultStreamTestCase {
 
     private static final Logger log = Logger.getLogger(CallbackTestCase.class);
     private volatile AtomicInteger count;
+    private volatile AtomicInteger countStream;
     private volatile boolean eventArrived;
     private volatile AtomicInteger failedCount;
     private volatile boolean failedCaught;
@@ -47,6 +50,7 @@ public class FaultStreamTestCase {
     @BeforeMethod
     public void init() {
         count = new AtomicInteger(0);
+        countStream = new AtomicInteger(0);
         eventArrived = false;
         failedCount = new AtomicInteger(0);
         failedCaught = false;
@@ -87,8 +91,8 @@ public class FaultStreamTestCase {
         logger.addAppender(appender);
         try {
             inputHandler.send(new Object[]{"IBM", 0f, 100L});
-            AssertJUnit.assertTrue(appender.getMessages().contains("Error when running faultAdd(). Exception on " +
-                    "class 'FaultFunctionExtension'"));
+            AssertJUnit.assertTrue(appender.getMessages().contains("Error when running faultAdd(). " +
+                    "Exception on class 'io.siddhi.core.stream.FaultFunctionExtension'"));
         } catch (Exception e) {
             Assert.fail("Unexpected exception occurred when testing.", e);
         } finally {
@@ -101,7 +105,7 @@ public class FaultStreamTestCase {
 
     }
 
-    @Test
+    @Test(dependsOnMethods = "faultStreamTest1")
     public void faultStreamTest2() throws InterruptedException {
         log.info("faultStreamTest2-Tests logging when fault handling is set to log.");
 
@@ -137,7 +141,7 @@ public class FaultStreamTestCase {
         try {
             inputHandler.send(new Object[]{"IBM", 0f, 100L});
             AssertJUnit.assertTrue(appender.getMessages().contains("Error when running faultAdd(). Exception on " +
-                    "class 'FaultFunctionExtension'"));
+                    "class 'io.siddhi.core.stream.FaultFunctionExtension'"));
         } catch (Exception e) {
             Assert.fail("Unexpected exception occurred when testing.", e);
         } finally {
@@ -149,7 +153,7 @@ public class FaultStreamTestCase {
         AssertJUnit.assertFalse(eventArrived);
     }
 
-    @Test
+    @Test(dependsOnMethods = "faultStreamTest2")
     public void faultStreamTest3() throws InterruptedException {
         log.info("faultStreamTest3-Tests fault handling when it's set to stream. " +
                 "No errors would be logged since exceptions are being gracefully handled.");
@@ -198,7 +202,7 @@ public class FaultStreamTestCase {
 
     }
 
-    @Test
+    @Test(dependsOnMethods = "faultStreamTest3")
     public void faultStreamTest4() throws InterruptedException {
         log.info("faultStreamTest4-Tests fault handling when it's set to stream. " +
                 "Events would be available in the corresponding fault stream");
@@ -250,7 +254,7 @@ public class FaultStreamTestCase {
         AssertJUnit.assertTrue(eventArrived);
     }
 
-    @Test
+    @Test(dependsOnMethods = "faultStreamTest4")
     public void faultStreamTest5() throws InterruptedException {
         log.info("faultStreamTest5-Tests fault handling when it's set to stream. " +
                 "Events would be available in the corresponding fault stream");
@@ -300,7 +304,7 @@ public class FaultStreamTestCase {
     }
 
 
-    @Test
+    @Test(dependsOnMethods = "faultStreamTest5")
     public void faultStreamTest6() throws InterruptedException {
         log.info("faultStreamTest6-Tests logging by default when fault handling is not configured "
                 + "explicitly at sink level during publishing failures.");
@@ -347,7 +351,7 @@ public class FaultStreamTestCase {
 
     }
 
-    @Test
+    @Test(dependsOnMethods = "faultStreamTest6")
     public void faultStreamTest7() throws InterruptedException {
         log.info("faultStreamTest7-Tests fault handling when it's set to log. " +
                 "Events would be logged and dropped during publishing failure at Sink");
@@ -393,10 +397,24 @@ public class FaultStreamTestCase {
         }
     }
 
-    @Test
+    @Test//(dependsOnMethods = "faultStreamTest7")
     public void faultStreamTest8() throws InterruptedException {
         log.info("faultStreamTest8-Tests fault handling when it's set to wait. " +
                 "Thread would be waiting until Sink reconnects.");
+
+        InMemoryBroker.Subscriber subscriptionIBM = new InMemoryBroker.Subscriber() {
+            @Override
+            public void onMessage(Object msg) {
+                EventPrinter.print(new Event[]{(Event) msg});
+                log.info(new Throwable());
+                count.incrementAndGet();
+            }
+
+            @Override
+            public String getTopic() {
+                return "IBM";
+            }
+        };
 
         SiddhiManager siddhiManager = new SiddhiManager();
 
@@ -433,23 +451,26 @@ public class FaultStreamTestCase {
                 @Override
                 public void run() {
                     try {
-                        inputHandler.send(new Object[]{"IBM", 0f, 100L});
+                        inputHandler.send(new Object[]{"IBM", 5f, 100L});
                     } catch (InterruptedException e) {
                     }
                 }
             };
             thread.start();
-            Thread.sleep(500);
+            Thread.sleep(6000);
             AssertJUnit.assertTrue(appender.getMessages() == null);
+            InMemoryBroker.subscribe(subscriptionIBM);
+            Thread.sleep(10000);
         } catch (Exception e) {
             Assert.fail("Unexpected exception occurred when testing.", e);
         } finally {
             logger.removeAppender(appender);
             siddhiAppRuntime.shutdown();
+            InMemoryBroker.unsubscribe(subscriptionIBM);
         }
     }
 
-    @Test
+    @Test(dependsOnMethods = "faultStreamTest8")
     public void faultStreamTest9() throws InterruptedException {
         log.info("faultStreamTest9-Tests fault handling when it's set to stream at Sink but, " +
                 "the fault stream is not configured. Events will be logged and dropped.");
@@ -499,8 +520,7 @@ public class FaultStreamTestCase {
             thread.start();
             Thread.sleep(500);
             AssertJUnit.assertTrue(appender.getMessages().contains("after consuming events from Stream " +
-                    "'outputStream', Dropping event at Sink 'inMemory' at 'outputStream' as its still " +
-                    "trying to reconnect!"));
+                    "'outputStream', Subscriber for topic 'IBM' is unavailable. Hence, dropping event"));
         } catch (Exception e) {
             Assert.fail("Unexpected exception occurred when testing.", e);
         } finally {
@@ -510,7 +530,7 @@ public class FaultStreamTestCase {
         }
     }
 
-    @Test
+    @Test(dependsOnMethods = "faultStreamTest9")
     public void faultStreamTest10() throws InterruptedException {
         log.info("faultStreamTest10-Tests fault handling when it's set to stream at Sink. " +
                 "The events will be available in the corresponding fault stream.");
@@ -575,7 +595,7 @@ public class FaultStreamTestCase {
         Assert.assertEquals(count.get(), 1);
     }
 
-    @Test
+    @Test(dependsOnMethods = "faultStreamTest10")
     public void faultStreamTest11() throws Exception {
 
         log.info("faultStreamTest11-Tests capturing runtime exceptions by registering an exception " +
@@ -643,5 +663,344 @@ public class FaultStreamTestCase {
         Assert.assertTrue(failedCaught);
         Assert.assertEquals(count.get(), 2);
         Assert.assertEquals(failedCount.get(), 1);
+    }
+
+    @Test(dependsOnMethods = "faultStreamTest11")
+    public void faultStreamTest12() throws InterruptedException {
+        log.info("faultStreamTest12-Tests fault handling for async when it's set to log. " +
+                "Events would be logged and dropped during publishing failure at Sink");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String siddhiApp = "" +
+                "@OnError(action='stream')" +
+                "define stream cseEventStream (symbol string, price float, volume long);" +
+                "\n" +
+                "@sink(type='testAsyncInMemory', topic='{{symbol}}', on.error='log', @map(type='passThrough')) " +
+                "define stream outputStream (symbol string, price float, sym1 string);" +
+                "\n" +
+                "@info(name = 'query1') " +
+                "from cseEventStream " +
+                "select symbol, price , symbol as sym1 " +
+                "insert into outputStream ;" +
+                "";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
+        siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                Assert.assertTrue(events[0].getData(0) != null);
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("cseEventStream");
+        siddhiAppRuntime.start();
+
+        Logger logger = Logger.getLogger(Sink.class);
+        UnitTestAppender appender = new UnitTestAppender();
+        logger.addAppender(appender);
+        try {
+            inputHandler.send(new Object[]{"IBM", 0f, 100L});
+            Thread.sleep(6000);
+            AssertJUnit.assertTrue(appender.getMessages().contains("Dropping event at Sink 'testAsyncInMemory' at"));
+        } catch (Exception e) {
+            Assert.fail("Unexpected exception occurred when testing.", e);
+        } finally {
+            logger.removeAppender(appender);
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "faultStreamTest12")
+    public void faultStreamTest13() throws InterruptedException {
+        log.info("faultStreamTest13-Tests fault handling when async set to wait. " +
+                "Thread would be waiting until Sink reconnects.");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        InMemoryBroker.Subscriber subscriptionIBM = new InMemoryBroker.Subscriber() {
+            @Override
+            public void onMessage(Object msg) {
+                EventPrinter.print(new Event[]{(Event) msg});
+                count.incrementAndGet();
+            }
+
+            @Override
+            public String getTopic() {
+                return "IBM";
+            }
+        };
+        InMemoryBroker.subscribe(subscriptionIBM);
+
+        String siddhiApp = "" +
+                "@OnError(action='stream')" +
+                "define stream cseEventStream (symbol string, price float, volume long);" +
+                "\n" +
+                "@sink(type='testAsyncInMemory', topic='{{symbol}}', on.error='wait', @map(type='passThrough')) " +
+                "define stream outputStream (symbol string, price float, sym1 string);" +
+                "\n" +
+                "@info(name = 'query1') " +
+                "from cseEventStream " +
+                "select symbol, price, symbol as sym1 " +
+                "insert into outputStream ;" +
+                "";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
+        siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                countStream.incrementAndGet();
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("cseEventStream");
+        siddhiAppRuntime.start();
+
+        Logger logger = Logger.getLogger(Sink.class);
+        UnitTestAppender appender = new UnitTestAppender();
+        logger.addAppender(appender);
+        TestAsyncInMemory.fail = true;
+        try {
+            Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        inputHandler.send(new Object[]{"IBM", 0f, 100L});
+                        inputHandler.send(new Object[]{"IBM", 1f, 100L});
+                    } catch (InterruptedException e) {
+                    }
+                }
+            };
+            thread.start();
+            Thread.sleep(6000);
+            Assert.assertTrue(appender.getMessages().contains("error while connecting at Sink 'testAsyncInMemory'" +
+                    " at 'outputStream', will retry in"));
+            Assert.assertEquals(countStream.get(), 1);
+            Assert.assertEquals(count.get(), 0);
+        } catch (Exception e) {
+            Assert.fail("Unexpected exception occurred when testing.", e);
+        } finally {
+            logger.removeAppender(appender);
+            siddhiAppRuntime.shutdown();
+            InMemoryBroker.unsubscribe(subscriptionIBM);
+        }
+    }
+
+    @Test(dependsOnMethods = "faultStreamTest13")
+    public void faultStreamTest14() throws InterruptedException {
+        log.info("faultStreamTest14-Tests fault handling when async set to wait. " +
+                "Thread would be waiting until Sink reconnects.");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        InMemoryBroker.Subscriber subscriptionIBM = new InMemoryBroker.Subscriber() {
+            @Override
+            public void onMessage(Object msg) {
+                EventPrinter.print(new Event[]{(Event) msg});
+                count.incrementAndGet();
+            }
+
+            @Override
+            public String getTopic() {
+                return "IBM";
+            }
+        };
+        InMemoryBroker.subscribe(subscriptionIBM);
+
+        String siddhiApp = "" +
+                "@OnError(action='stream')" +
+                "define stream cseEventStream (symbol string, price float, volume long);" +
+                "\n" +
+                "@sink(type='testAsyncInMemory', topic='{{symbol}}', on.error='wait', @map(type='passThrough')) " +
+                "define stream outputStream (symbol string, price float, sym1 string);" +
+                "\n" +
+                "@info(name = 'query1') " +
+                "from cseEventStream " +
+                "select symbol, price, symbol as sym1 " +
+                "insert into outputStream ;" +
+                "";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
+        siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                countStream.incrementAndGet();
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("cseEventStream");
+        siddhiAppRuntime.start();
+
+        Logger logger = Logger.getLogger(Sink.class);
+        UnitTestAppender appender = new UnitTestAppender();
+        logger.addAppender(appender);
+        TestAsyncInMemory.failOnce = true;
+        try {
+            Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        inputHandler.send(new Object[]{"IBM", 6f, 100L});
+                        inputHandler.send(new Object[]{"IBM", 7f, 100L});
+                    } catch (InterruptedException e) {
+                    }
+                }
+            };
+            thread.start();
+            Thread.sleep(6000);
+            Assert.assertTrue(appender.getMessages() == null);
+            Assert.assertEquals(count.get(), 2);
+            Assert.assertEquals(countStream.get(), 2);
+        } catch (Exception e) {
+            Assert.fail("Unexpected exception occurred when testing.", e);
+        } finally {
+            logger.removeAppender(appender);
+            siddhiAppRuntime.shutdown();
+            InMemoryBroker.unsubscribe(subscriptionIBM);
+        }
+    }
+
+    @Test(dependsOnMethods = "faultStreamTest14")
+    public void faultStreamTest15() throws InterruptedException {
+        log.info("faultStreamTest15-Tests fault handling when async set to stream at Sink. " +
+                "The events will be available in the corresponding fault stream.");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String siddhiApp = "" +
+                "@OnError(action='stream')" +
+                "define stream cseEventStream (symbol string, price float, volume long);" +
+                "\n" +
+                "@OnError(action='stream')" +
+                "@sink(type='testAsyncInMemory', topic='{{symbol}}', on.error='stream', @map(type='passThrough')) " +
+                "define stream outputStream (symbol string, price float, sym1 string);" +
+                "\n" +
+                "@info(name = 'query1') " +
+                "from cseEventStream " +
+                "select symbol, price , symbol as sym1 " +
+                "insert into outputStream ;" +
+                "";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
+        siddhiAppRuntime.addCallback("!outputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                Assert.assertTrue(events[0].getData(3) != null);
+                eventArrived = true;
+                countStream.incrementAndGet();
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("cseEventStream");
+        siddhiAppRuntime.start();
+
+        Logger loggerSink = Logger.getLogger(Sink.class);
+        Logger loggerStreamJunction = Logger.getLogger(StreamJunction.class);
+        UnitTestAppender appender = new UnitTestAppender();
+        loggerSink.addAppender(appender);
+        loggerStreamJunction.addAppender(appender);
+        try {
+            Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        inputHandler.send(new Object[]{"IBM", 0f, 100L});
+                    } catch (InterruptedException e) {
+                    }
+                }
+            };
+            thread.start();
+            Thread.sleep(500);
+            AssertJUnit.assertTrue(appender.getMessages() == null);
+        } catch (Exception e) {
+            Assert.fail("Unexpected exception occurred when testing.", e);
+        } finally {
+            loggerSink.removeAppender(appender);
+            loggerStreamJunction.removeAppender(appender);
+            siddhiAppRuntime.shutdown();
+        }
+        Assert.assertTrue(eventArrived);
+        Assert.assertEquals(count.get(), 0);
+        Assert.assertEquals(countStream.get(), 1);
+    }
+
+    @Test(dependsOnMethods = "faultStreamTest15")
+    public void faultStreamTest16() throws InterruptedException {
+        log.info("faultStreamTest13-Tests fault handling when async set to wait. " +
+                "Thread would be waiting until Sink reconnects.");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        InMemoryBroker.Subscriber subscriptionIBM = new InMemoryBroker.Subscriber() {
+            @Override
+            public void onMessage(Object msg) {
+                EventPrinter.print(new Event[]{(Event) msg});
+                count.incrementAndGet();
+            }
+
+            @Override
+            public String getTopic() {
+                return "IBM";
+            }
+        };
+        InMemoryBroker.subscribe(subscriptionIBM);
+
+        String siddhiApp = "" +
+                "@OnError(action='stream')" +
+                "define stream cseEventStream (symbol string, price float, volume long);" +
+                "\n" +
+                "@sink(type='testAsyncInMemory', topic='{{symbol}}', on.error='wait', @map(type='passThrough')) " +
+                "define stream outputStream (symbol string, price float, sym1 string);" +
+                "\n" +
+                "@info(name = 'query1') " +
+                "from cseEventStream " +
+                "select symbol, price, symbol as sym1 " +
+                "insert into outputStream ;" +
+                "";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(siddhiApp);
+        siddhiAppRuntime.addCallback("outputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                countStream.incrementAndGet();
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("cseEventStream");
+        siddhiAppRuntime.start();
+
+        Logger logger = Logger.getLogger(Sink.class);
+        UnitTestAppender appender = new UnitTestAppender();
+        logger.addAppender(appender);
+        TestAsyncInMemory.fail = true;
+        TestAsyncInMemory.failRuntime = true;
+        try {
+            Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        inputHandler.send(new Object[]{"IBM", 0f, 100L});
+                        inputHandler.send(new Object[]{"IBM", 1f, 100L});
+                    } catch (InterruptedException e) {
+                    }
+                }
+            };
+            thread.start();
+            Thread.sleep(6000);
+            AssertJUnit.assertTrue(appender.getMessages().contains("as on.error='wait' does not handle"));
+            Assert.assertEquals(count.get(), 0);
+            Assert.assertEquals(countStream.get(), 2);
+        } catch (Exception e) {
+            Assert.fail("Unexpected exception occurred when testing.", e);
+        } finally {
+            logger.removeAppender(appender);
+            siddhiAppRuntime.shutdown();
+            InMemoryBroker.unsubscribe(subscriptionIBM);
+        }
     }
 }

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/SinkOptionSinkMapper.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/SinkOptionSinkMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/SinkOptionSinkMapper.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/SinkOptionSinkMapper.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c)  2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.transport;
+
+import io.siddhi.annotation.Example;
+import io.siddhi.annotation.Extension;
+import io.siddhi.core.config.SiddhiAppContext;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.stream.output.sink.SinkListener;
+import io.siddhi.core.stream.output.sink.SinkMapper;
+import io.siddhi.core.util.config.ConfigReader;
+import io.siddhi.core.util.transport.Option;
+import io.siddhi.core.util.transport.OptionHolder;
+import io.siddhi.core.util.transport.TemplateBuilder;
+import io.siddhi.query.api.definition.StreamDefinition;
+
+import java.util.Map;
+
+/**
+ * Implementation of {@link SinkMapper} representing pass-through scenario where no mapping is done and
+ * {@link Event}s are send directly to transports.
+ */
+@Extension(
+        name = "sinkOption",
+        namespace = "sinkMapper",
+        description = "Pass-through mapper passed events (Event[]) through without any mapping or modifications.",
+        examples = @Example(
+                syntax = "@sink(type='inMemory', @map(type='passThrough'))\n" +
+                        "define stream BarStream (symbol string, price float, volume long);",
+                description = "In the following example BarStream uses passThrough outputmapper which emit " +
+                        "Siddhi event directly without any transformation into sink."
+        )
+)
+public class SinkOptionSinkMapper extends SinkMapper {
+
+    private Option topicOption;
+    private String prefix;
+
+    @Override
+    public String[] getSupportedDynamicOptions() {
+        return new String[0];
+    }
+
+    @Override
+    public void init(StreamDefinition streamDefinition, OptionHolder optionHolder, Map<String, TemplateBuilder>
+            payloadTemplateBuilderMap, ConfigReader mapperConfigReader, SiddhiAppContext siddhiAppContext) {
+        topicOption = sinkOptionHolder.validateAndGetOption("topic");
+        prefix = sinkOptionHolder.validateAndGetStaticValue("prefix");
+    }
+
+    @Override
+    public Class[] getOutputEventClasses() {
+        return new Class[]{Event[].class, Event.class};
+    }
+
+    @Override
+    public void mapAndSend(Event[] events, OptionHolder optionHolder,
+                           Map<String, TemplateBuilder> payloadTemplateBuilderMap, SinkListener sinkListener) {
+        for (Event event : events) {
+            String topic = topicOption.getValue(event);
+            event.getData()[0] = sinkType;
+            event.getData()[1] = topic;
+            event.getData()[2] = prefix;
+        }
+        sinkListener.publish(events);
+    }
+
+    @Override
+    public void mapAndSend(Event event, OptionHolder optionHolder,
+                           Map<String, TemplateBuilder> payloadTemplateBuilderMap, SinkListener sinkListener) {
+        String topic = topicOption.getValue(event);
+        event.getData()[0] = sinkType;
+        event.getData()[1] = topic;
+        event.getData()[2] = prefix;
+        sinkListener.publish(event);
+    }
+}

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/TestAsyncInMemory.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/TestAsyncInMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/TestAsyncInMemory.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/TestAsyncInMemory.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.transport;
+
+import io.siddhi.annotation.Example;
+import io.siddhi.annotation.Extension;
+import io.siddhi.annotation.Parameter;
+import io.siddhi.annotation.util.DataType;
+import io.siddhi.core.config.SiddhiAppContext;
+import io.siddhi.core.exception.ConnectionUnavailableException;
+import io.siddhi.core.exception.SiddhiAppRuntimeException;
+import io.siddhi.core.stream.output.sink.InMemorySink;
+import io.siddhi.core.util.config.ConfigReader;
+import io.siddhi.core.util.snapshot.state.State;
+import io.siddhi.core.util.snapshot.state.StateFactory;
+import io.siddhi.core.util.transport.DynamicOptions;
+import io.siddhi.core.util.transport.OptionHolder;
+import io.siddhi.query.api.definition.StreamDefinition;
+
+@Extension(
+        name = "testAsyncInMemory",
+        namespace = "sink",
+        description = "In-memory sink for testing connection unavailable use-case",
+        parameters = @Parameter(name = "topic", type = DataType.STRING, description = "Event will be delivered to all" +
+                "the subscribers of the same topic"),
+        examples = @Example(
+                syntax = "@sink(type='inMemory', @map(type='passThrough'),\n" +
+                        "define stream BarStream (symbol string, price float, volume long)",
+                description = "In this example BarStream uses inMemory transport which emit the Siddhi " +
+                        "events internally without using external transport and transformation."
+        )
+)
+public class TestAsyncInMemory extends InMemorySink {
+    private static final String TOPIC_KEY = "topic";
+    public static int numberOfErrorOccurred = 0;
+    public static boolean fail;
+    public static boolean failRuntime;
+    public static boolean failOnce;
+    private SiddhiAppContext siddhiAppContext;
+
+    public TestAsyncInMemory() {
+        this.failOnce = false;
+        this.fail = false;
+        this.failRuntime = false;
+        this.numberOfErrorOccurred = 0;
+    }
+
+    @Override
+    protected StateFactory<State> init(StreamDefinition outputStreamDefinition, OptionHolder optionHolder,
+                                       ConfigReader sinkConfigReader, SiddhiAppContext siddhiAppContext) {
+        this.siddhiAppContext = siddhiAppContext;
+        optionHolder.validateAndGetOption(TOPIC_KEY);
+        super.init(outputStreamDefinition, optionHolder, sinkConfigReader, siddhiAppContext);
+        return null;
+    }
+
+    @Override
+    public void connect() throws ConnectionUnavailableException {
+        if (fail || failOnce) {
+            failOnce = false;
+            numberOfErrorOccurred++;
+            throw new ConnectionUnavailableException("Connection unavailable during connection");
+        }
+        super.connect();
+    }
+
+    @Override
+    public void publish(Object payload, DynamicOptions dynamicOptions, State state) {
+        siddhiAppContext.getExecutorService().execute(new Publisher(payload, dynamicOptions, state, this));
+    }
+
+
+    class Publisher implements Runnable {
+
+        private final Object payload;
+        private final DynamicOptions dynamicOptions;
+        private final State state;
+        private final TestAsyncInMemory sink;
+
+        public Publisher(Object payload, DynamicOptions dynamicOptions, State state, TestAsyncInMemory sink) {
+            this.payload = payload;
+            this.dynamicOptions = dynamicOptions;
+            this.state = state;
+            this.sink = sink;
+        }
+
+        @Override
+        public void run() {
+            try {
+                if (fail || failOnce) {
+                    failOnce = false;
+                    numberOfErrorOccurred++;
+                    throw new ConnectionUnavailableException("Connection unavailable during publishing");
+                }
+                sink.send(payload, dynamicOptions, state);
+            } catch (Throwable e) {
+                if (failRuntime) {
+                    onError(payload, dynamicOptions, new SiddhiAppRuntimeException(e.getMessage(), e));
+                } else {
+                    onError(payload, dynamicOptions, new ConnectionUnavailableException(e.getMessage(), e));
+                }
+            }
+        }
+    }
+
+    private void send(Object payload, DynamicOptions dynamicOptions, State state)
+            throws Throwable {
+        super.publish(payload, dynamicOptions, state);
+    }
+}

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/window/WindowDefinitionTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/window/WindowDefinitionTestCase.java
@@ -158,7 +158,7 @@ public class WindowDefinitionTestCase {
                 "@sink(name='log')\n" +
                 "define stream AlertStream (amount double);\n" +
                 "\n" +
-                "-- @store(type='rdbms' , datasource='WSO2_CARBON_DB') \n" +
+                "-- @store(type='rdbms', datasource='WSO2_CARBON_DB') \n" +
                 "@primaryKey('name') \n" +
                 "define table SummarizedTable (name string, total double);\n" +
                 "\n" +

--- a/modules/siddhi-core/src/test/resources/testng.xml
+++ b/modules/siddhi-core/src/test/resources/testng.xml
@@ -150,6 +150,7 @@
             <class name="io.siddhi.core.stream.CallbackTestCase"/>
             <class name="io.siddhi.core.stream.ExceptionHandlerTestCase"/>
             <class name="io.siddhi.core.stream.JunctionTestCase"/>
+            <class name="io.siddhi.core.stream.FaultStreamTestCase"/>
             <class name="io.siddhi.core.stream.event.ComplexEventChunkTestCase"/>
             <class name="io.siddhi.core.stream.event.EventTestCase"/>
             <class name="io.siddhi.core.stream.output.sink.LogSinkTest"/>


### PR DESCRIPTION
Purpose
> Support a way to retrieve the sink options and type at sink mapper. Fixes #1469
> Support error handling (log/wait/fault-stream) when event sinks publish data asynchronously. Fixes #1465 
> Fix time management in not pattern cases.

## Release note
> #1469 Support a way to retrieve the sink options and type at sink mapper. 
> #1465 Support error handling (log/wait/fault-stream) when event sinks publish data asynchronously. 
