### PR TITLE
Change the behavior of in-memory tables to support multiple '@index' annotations

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/partition/PartitionRuntimeImpl.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/partition/PartitionRuntimeImpl.java
@@ -99,7 +99,8 @@ public class PartitionRuntimeImpl implements PartitionRuntime {
                                 Partition partition, int partitionIndex, SiddhiAppContext siddhiAppContext) {
         this.siddhiAppContext = siddhiAppContext;
         if (partition.getPartitionTypeMap().isEmpty()) {
-            throw new SiddhiAppCreationException("Partition must have at least one executor. But found none.");
+            throw new SiddhiAppCreationException("Partition must have at least one partition executor. " +
+                    "But found none.");
         }
         try {
             Element element = AnnotationHelper.getAnnotationElement("info", "name",

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/PartitionParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/PartitionParser.java
@@ -51,9 +51,9 @@ public class PartitionParser {
                 siddhiAppRuntimeBuilder.getStreamDefinitionMap();
         ConcurrentMap<String, AbstractDefinition> windowDefinitionMap =
                 siddhiAppRuntimeBuilder.getWindowDefinitionMap();
+        validateStreamPartitions(partition.getPartitionTypeMap(), streamDefinitionMap, windowDefinitionMap);
         PartitionRuntimeImpl partitionRuntime = new PartitionRuntimeImpl(streamDefinitionMap, windowDefinitionMap,
                 siddhiAppRuntimeBuilder.getStreamJunctions(), partition, partitionIndex, siddhiAppContext);
-        validateStreamPartitions(partition.getPartitionTypeMap(), streamDefinitionMap, windowDefinitionMap);
         for (Query query : partition.getQueryList()) {
             List<VariableExpressionExecutor> executors = new ArrayList<VariableExpressionExecutor>();
             ConcurrentMap<String, AbstractDefinition> combinedStreamMap =
@@ -93,7 +93,7 @@ public class PartitionParser {
             if ((!streamDefinitionMap.containsKey(entry.getKey())) &&
                     (!windowDefinitionMap.containsKey(entry.getKey()))) {
                 throw new SiddhiAppCreationException("Stream/window with name '" + entry.getKey() +
-                        "' does not defined!",
+                        "' is not defined!",
                         entry.getValue().getQueryContextStartIndex(),
                         entry.getValue().getQueryContextEndIndex());
             }

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/IndexTableTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/IndexTableTestCase.java
@@ -21,13 +21,12 @@ package io.siddhi.core.query.table;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
-import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import io.siddhi.core.util.SiddhiTestHelper;
 import io.siddhi.query.api.exception.AttributeNotExistException;
-import io.siddhi.query.api.exception.DuplicateAnnotationException;
+import io.siddhi.query.api.exception.SiddhiAppValidationException;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
@@ -2006,7 +2005,8 @@ public class IndexTableTestCase {
                 "define stream CheckStockStream (symbol string, volume long); " +
                 "define stream UpdateStockStream (symbol string, price float, volume long);" +
                 "@PrimaryKey('symbol') " +
-                "@Index('price','volume') " +
+                "@Index('price') " +
+                "@Index('volume') " +
                 "define table StockTable (symbol string, price float, volume long); ";
         String query = "" +
                 "@info(name = 'query1') " +
@@ -2072,7 +2072,8 @@ public class IndexTableTestCase {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "define stream CheckStockStream (symbol string, volume long); " +
                 "define stream UpdateStockStream (symbol string, price float, volume long);" +
-                "@Index('symbol', 'volume') " +
+                "@Index('symbol') " +
+                "@Index('volume') " +
                 "define table StockTable (symbol string, price float, volume long); ";
         String query = "" +
                 "@info(name = 'query1') " +
@@ -2154,14 +2155,14 @@ public class IndexTableTestCase {
         }
     }
 
-    @Test(expectedExceptions = SiddhiAppCreationException.class)
+    @Test(expectedExceptions = SiddhiAppValidationException.class)
     public void indexTableTest31() throws InterruptedException {
         log.info("indexTableTest31");
 
         SiddhiManager siddhiManager = new SiddhiManager();
         String streams = "" +
                 "define stream StockStream (symbol string, price float, volume long); " +
-                "@Index('symbol', 'symbol') " +
+                "@Index('symbol', 'volume') " +
                 "define table StockTable (symbol string, price float, volume long); ";
         String query = "" +
                 "@info(name = 'query1') " +
@@ -2180,7 +2181,7 @@ public class IndexTableTestCase {
         }
     }
 
-    @Test(expectedExceptions = DuplicateAnnotationException.class)
+    @Test(expectedExceptions = SiddhiAppValidationException.class)
     public void indexTableTest32() throws InterruptedException {
         log.info("indexTableTest32");
 
@@ -2188,7 +2189,7 @@ public class IndexTableTestCase {
         String streams = "" +
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "@Index('symbol') " +
-                "@Index('volume') " +
+                "@Index('symbol') " +
                 "define table StockTable (symbol string, price float, volume long); ";
         String query = "" +
                 "@info(name = 'query1') " +

--- a/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/util/AnnotationHelper.java
+++ b/modules/siddhi-query-api/src/main/java/io/siddhi/query/api/util/AnnotationHelper.java
@@ -23,6 +23,7 @@ import io.siddhi.query.api.annotation.Element;
 import io.siddhi.query.api.exception.DuplicateAnnotationException;
 
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -53,6 +54,16 @@ public class AnnotationHelper {
             }
         }
         return annotation;
+    }
+
+    public static List<Annotation> getAnnotations(String annotationName, List<Annotation> annotationList) {
+        List<Annotation> annotations = new LinkedList<>();
+        for (Annotation aAnnotation : annotationList) {
+            if (annotationName.equalsIgnoreCase(aAnnotation.getName())) {
+                annotations.add(aAnnotation);
+            }
+        }
+        return annotations;
     }
 
     // TODO: 1/28/17 update helper methods to work with nested annotations.


### PR DESCRIPTION
## Purpose
> To uniform the behavior of @index annotation of the table.
> For more information refer https://github.com/siddhi-io/siddhi/issues/1228

## Release Notes
The behavior of `@index` annotation of the in-memory table is modified to accept only one index element per annotation. Through this, to use multiple indexes on the table multiple '@index(<index key>)' annotations should be defined per each index key.