### PR TITLE
Fixed #1516 State activeUseCount may be -1 when running in multithreads

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/snapshot/state/PartitionStateHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/snapshot/state/PartitionStateHolder.java
@@ -51,7 +51,7 @@ public class PartitionStateHolder implements StateHolder {
     public void returnState(State state) {
         String partitionFlowId = SiddhiAppContext.getPartitionFlowId();
         String groupByFlowId = SiddhiAppContext.getGroupByFlowId();
-        if (state.activeUseCount == 0) {
+        if (state.getActiveUseCount() == 0) {
             try {
                 if (state.canDestroy()) {
                     removeState(partitionFlowId, groupByFlowId);
@@ -61,10 +61,10 @@ public class PartitionStateHolder implements StateHolder {
                         "' and the group by key '" + groupByFlowId + "', due to error! " + t.getMessage(), t);
                 removeState(partitionFlowId, groupByFlowId);
             }
-        } else if (state.activeUseCount < 0) {
+        } else if (state.getActiveUseCount() < 0) {
             throw new SiddhiAppRuntimeException("State active count has reached less then zero for partition key '" +
                     partitionFlowId + "' and the group by key '" + groupByFlowId + "', current value is " +
-                    state.activeUseCount);
+                    state.getActiveUseCount());
         }
     }
 
@@ -78,6 +78,7 @@ public class PartitionStateHolder implements StateHolder {
         }
     }
 
+    @Override
     public Map<String, Map<String, State>> getAllStates() {
         return states;
     }
@@ -106,7 +107,7 @@ public class PartitionStateHolder implements StateHolder {
              iterator.hasNext(); ) {
             Map.Entry<String, State> stateEntry = iterator.next();
             State state = stateEntry.getValue();
-            if (state.activeUseCount == 0) {
+            if (state.getActiveUseCount() == 0) {
                 try {
                     if (state.canDestroy()) {
                         iterator.remove();
@@ -116,10 +117,10 @@ public class PartitionStateHolder implements StateHolder {
                             "' and the group by key '" + stateEntry.getKey() + "', due to error! " + t.getMessage(), t);
                     iterator.remove();
                 }
-            } else if (state.activeUseCount < 0) {
+            } else if (state.getActiveUseCount() < 0) {
                 throw new SiddhiAppRuntimeException("State active count has reached less then zero for partition key '"
                         + partitionFlowId + "' and the group by key '" + stateEntry.getKey() + "', current value is " +
-                        state.activeUseCount);
+                        state.getActiveUseCount());
             }
 
         }
@@ -137,7 +138,7 @@ public class PartitionStateHolder implements StateHolder {
                  stateIterator.hasNext(); ) {
                 Map.Entry<String, State> stateEntry = stateIterator.next();
                 State state = stateEntry.getValue();
-                if (state.activeUseCount == 0) {
+                if (state.getActiveUseCount() == 0) {
                     try {
                         if (state.canDestroy()) {
                             stateIterator.remove();
@@ -148,11 +149,11 @@ public class PartitionStateHolder implements StateHolder {
                                 t.getMessage(), t);
                         stateIterator.remove();
                     }
-                } else if (state.activeUseCount < 0) {
+                } else if (state.getActiveUseCount() < 0) {
                     throw new SiddhiAppRuntimeException("State active count has reached less then zero for " +
                             "partition key '" + statesEntry.getKey() + "' and the group by key '" +
                             stateEntry.getKey() + "', current value is " +
-                            state.activeUseCount);
+                            state.getActiveUseCount());
                 }
             }
             if (statesEntry.getValue().isEmpty()) {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/snapshot/state/PartitionSyncStateHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/snapshot/state/PartitionSyncStateHolder.java
@@ -33,22 +33,23 @@ public class PartitionSyncStateHolder implements StateHolder {
     @Override
     public synchronized State getState() {
         State state = partitionStateHolder.getState();
-        state.activeUseCount++;
+        state.increaseActiveUseCount();
         return state;
     }
 
     @Override
     public synchronized void returnState(State state) {
-        state.activeUseCount--;
+        state.decreaseActiveUseCount();
         partitionStateHolder.returnState(state);
     }
 
 
+    @Override
     public synchronized Map<String, Map<String, State>> getAllStates() {
         Map<String, Map<String, State>> states = partitionStateHolder.getAllStates();
         for (Map<String, State> groupByStates : states.values()) {
             for (State state : groupByStates.values()) {
-                state.activeUseCount++;
+                state.increaseActiveUseCount();
             }
         }
         return states;
@@ -58,7 +59,7 @@ public class PartitionSyncStateHolder implements StateHolder {
     public synchronized Map<String, State> getAllGroupByStates() {
         Map<String, State> groupByStates = partitionStateHolder.getAllGroupByStates();
         for (State state : groupByStates.values()) {
-            state.activeUseCount++;
+            state.increaseActiveUseCount();
         }
         return groupByStates;
     }
@@ -71,7 +72,7 @@ public class PartitionSyncStateHolder implements StateHolder {
     @Override
     public synchronized void returnGroupByStates(Map states) {
         for (State state : ((Map<String, State>) states).values()) {
-            state.activeUseCount--;
+            state.decreaseActiveUseCount();
         }
         partitionStateHolder.returnGroupByStates(states);
     }
@@ -80,7 +81,7 @@ public class PartitionSyncStateHolder implements StateHolder {
     public synchronized void returnAllStates(Map states) {
         for (Map<String, State> groupByStates : ((Map<String, Map<String, State>>) states).values()) {
             for (State state : groupByStates.values()) {
-                state.activeUseCount--;
+                state.decreaseActiveUseCount();
             }
         }
         partitionStateHolder.returnAllStates(states);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/snapshot/state/State.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/snapshot/state/State.java
@@ -25,7 +25,33 @@ import java.util.Map;
  */
 public abstract class State {
 
-    int activeUseCount = 0;
+    private static final int INIT_ACTIVE_USE_COUNT = -0xFFFF;
+
+    /**
+     * if activeUseCount == INIT_ACTIVE_USE_COUNT, means the State object is just initialized.
+     * For just initialized state, getActiveUseCount will return 0,
+     * increaseActiveUseCount will set activeUseCount to 1,
+     * decreaseActiveUseCount will be skipped.
+     */
+    private int activeUseCount = INIT_ACTIVE_USE_COUNT;
+
+    public int getActiveUseCount() {
+        return activeUseCount == INIT_ACTIVE_USE_COUNT ? 0 : activeUseCount;
+    }
+
+    public void increaseActiveUseCount() {
+        if (activeUseCount == INIT_ACTIVE_USE_COUNT) {
+            activeUseCount = 1;
+        } else {
+            activeUseCount++;
+        }
+    }
+
+    public void decreaseActiveUseCount() {
+        if (activeUseCount != INIT_ACTIVE_USE_COUNT) {
+            activeUseCount--;
+        }
+    }
 
     public abstract boolean canDestroy();
 


### PR DESCRIPTION

## Purpose
    Fix the issue of State activeUseCount may be -1 when running same appruntime in multithreads.
## Goals
    Move the State activeUseCount update operations to State class methods and use flag to identify the initial status of State object.
## Approach
    First initialized the activeUseCount to a magic number -0xFFFF to avoid introduce another flag field for the initial status of state object. And define methods to handle the get and update request of activeUseCount.
    if activeUseCount == INIT_ACTIVE_USE_COUNT, means the State object is just initialized.For just initialized state, getActiveUseCount will return 0, increaseActiveUseCount will set activeUseCount to 1,
    decreaseActiveUseCount will be skipped.

## Release note
   Fixed issue of State activeUseCount may be -1 when running in multithreads

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
