### PR TITLE
Update SiddhiExtensionHolder when OSGI listener updates bundles

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/config/SiddhiContext.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/config/SiddhiContext.java
@@ -51,7 +51,8 @@ public class SiddhiContext {
     private IncrementalPersistenceStore incrementalPersistenceStore = null;
     private ConcurrentHashMap<String, DataSource> siddhiDataSources;
     private StatisticsConfiguration statisticsConfiguration;
-    private ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap;
+    private ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap
+            = new ConcurrentHashMap<Class, AbstractExtensionHolder>();
     private ConfigManager configManager = null;
     private SinkHandlerManager sinkHandlerManager = null;
     private SourceHandlerManager sourceHandlerManager = null;
@@ -59,10 +60,9 @@ public class SiddhiContext {
     private Map<String, Object> attributes;
 
     public SiddhiContext() {
-        SiddhiExtensionLoader.loadSiddhiExtensions(siddhiExtensions);
+        SiddhiExtensionLoader.loadSiddhiExtensions(siddhiExtensions, extensionHolderMap);
         siddhiDataSources = new ConcurrentHashMap<String, DataSource>();
         statisticsConfiguration = new StatisticsConfiguration(new SiddhiMetricsFactory());
-        extensionHolderMap = new ConcurrentHashMap<Class, AbstractExtensionHolder>();
         configManager = new InMemoryConfigManager();
         attributes = new ConcurrentHashMap<>();
         defaultDisrupterExceptionHandler = new ExceptionHandler<Object>() {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiExtensionLoader.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiExtensionLoader.java
@@ -19,11 +19,25 @@
 package io.siddhi.core.util;
 
 import io.siddhi.annotation.Extension;
+import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.executor.incremental.IncrementalAggregateBaseTimeFunctionExecutor;
 import io.siddhi.core.executor.incremental.IncrementalShouldUpdateFunctionExecutor;
 import io.siddhi.core.executor.incremental.IncrementalStartTimeEndTimeFunctionExecutor;
 import io.siddhi.core.executor.incremental.IncrementalTimeGetTimeZone;
 import io.siddhi.core.executor.incremental.IncrementalUnixTimeFunctionExecutor;
+import io.siddhi.core.function.Script;
+import io.siddhi.core.query.processor.stream.StreamProcessor;
+import io.siddhi.core.query.processor.stream.function.StreamFunctionProcessor;
+import io.siddhi.core.query.processor.stream.window.WindowProcessor;
+import io.siddhi.core.query.selector.attribute.aggregator.AttributeAggregatorExecutor;
+import io.siddhi.core.query.selector.attribute.aggregator.incremental.IncrementalAttributeAggregator;
+import io.siddhi.core.stream.input.source.Source;
+import io.siddhi.core.stream.input.source.SourceMapper;
+import io.siddhi.core.stream.output.sink.Sink;
+import io.siddhi.core.stream.output.sink.SinkMapper;
+import io.siddhi.core.stream.output.sink.distributed.DistributionStrategy;
+import io.siddhi.core.table.Table;
+import io.siddhi.core.util.extension.holder.AbstractExtensionHolder;
 import org.apache.log4j.Logger;
 import org.atteo.classindex.ClassIndex;
 import org.osgi.framework.Bundle;
@@ -32,8 +46,11 @@ import org.osgi.framework.BundleEvent;
 import org.osgi.framework.BundleListener;
 import org.osgi.framework.wiring.BundleWiring;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Class used to load Siddhi extensions.
@@ -41,17 +58,49 @@ import java.util.Map;
 public class SiddhiExtensionLoader {
 
     private static final Logger log = Logger.getLogger(SiddhiExtensionLoader.class);
+    private static List<Class> extensionNameSpaceList = new ArrayList<>();
+    private static final Class ATTRIBUTE_AGGREGATOR_EXECUTOR_CLASS = AttributeAggregatorExecutor.class;
+    private static final Class DISTRIBUTION_STRATEGY_CLASS = DistributionStrategy.class;
+    private static final Class FUNCTION_EXECUTOR_CLASS = FunctionExecutor.class;
+    private static final Class INCREMENTAL_ATTRIBUTE_AGGREGATOR_CLASS = IncrementalAttributeAggregator.class;
+    private static final Class SCRIPT_CLASS = Script.class;
+    private static final Class SINK_CLASS = Sink.class;
+    private static final Class SINK_MAPPER_CLASS = SinkMapper.class;
+    private static final Class SOURCE_CLASS = Source.class;
+    private static final Class SOURCE_MAPPER_CLASS = SourceMapper.class;
+    private static final Class STREAM_FUNCTION_PROCESSOR_CLASS = StreamFunctionProcessor.class;
+    private static final Class STREAM_PROCESSOR_CLASS = StreamProcessor.class;
+    private static final Class TABLE_CLASS = Table.class;
+    private static final Class WINDOW_PROCESSOR_CLASS = WindowProcessor.class;
+
+    static {
+        extensionNameSpaceList.add(DISTRIBUTION_STRATEGY_CLASS);
+        extensionNameSpaceList.add(SCRIPT_CLASS);
+        extensionNameSpaceList.add(SINK_CLASS);
+        extensionNameSpaceList.add(SINK_MAPPER_CLASS);
+        extensionNameSpaceList.add(SOURCE_CLASS);
+        extensionNameSpaceList.add(SOURCE_MAPPER_CLASS);
+        extensionNameSpaceList.add(TABLE_CLASS);
+        extensionNameSpaceList.add(ATTRIBUTE_AGGREGATOR_EXECUTOR_CLASS);
+        extensionNameSpaceList.add(FUNCTION_EXECUTOR_CLASS);
+        extensionNameSpaceList.add(INCREMENTAL_ATTRIBUTE_AGGREGATOR_CLASS);
+        extensionNameSpaceList.add(STREAM_FUNCTION_PROCESSOR_CLASS);
+        extensionNameSpaceList.add(STREAM_PROCESSOR_CLASS);
+        extensionNameSpaceList.add(WINDOW_PROCESSOR_CLASS);
+    }
 
     /**
      * Helper method to load the Siddhi extensions.
      *
      * @param siddhiExtensionsMap reference map for the Siddhi extension
+     * @param extensionHolderMap  reference map for the Siddhi extension holder
      */
-    public static void loadSiddhiExtensions(Map<String, Class> siddhiExtensionsMap) {
-        loadLocalExtensions(siddhiExtensionsMap);
+    public static void loadSiddhiExtensions(Map<String, Class> siddhiExtensionsMap,
+                                            ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap) {
+        loadLocalExtensions(siddhiExtensionsMap, extensionHolderMap);
         BundleContext bundleContext = ReferenceHolder.getInstance().getBundleContext();
         if (bundleContext != null) {
-            loadExtensionOSGI(bundleContext, siddhiExtensionsMap);
+            loadExtensionOSGI(bundleContext, siddhiExtensionsMap, extensionHolderMap);
         }
     }
 
@@ -60,9 +109,13 @@ public class SiddhiExtensionLoader {
      *
      * @param bundleContext       OSGi bundleContext
      * @param siddhiExtensionsMap reference map for the Siddhi extension
+     * @param extensionHolderMap  reference map for the Siddhi extension holder
      */
-    private static void loadExtensionOSGI(BundleContext bundleContext, Map<String, Class> siddhiExtensionsMap) {
-        ExtensionBundleListener extensionBundleListener = new ExtensionBundleListener(siddhiExtensionsMap);
+    private static void loadExtensionOSGI(BundleContext bundleContext,
+                                          Map<String, Class> siddhiExtensionsMap,
+                                          ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap) {
+        ExtensionBundleListener extensionBundleListener
+                = new ExtensionBundleListener(siddhiExtensionsMap, extensionHolderMap);
         bundleContext.addBundleListener(extensionBundleListener);
         extensionBundleListener.loadAllExtensions(bundleContext);
     }
@@ -71,11 +124,13 @@ public class SiddhiExtensionLoader {
      * Load Siddhi extensions in java non OSGi environment.
      *
      * @param siddhiExtensionsMap reference map for the Siddhi extension
+     * @param extensionHolderMap reference map for the Siddhi extension holder
      */
-    private static void loadLocalExtensions(Map<String, Class> siddhiExtensionsMap) {
+    private static void loadLocalExtensions(Map<String, Class> siddhiExtensionsMap,
+                                            ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap) {
         Iterable<Class<?>> extensions = ClassIndex.getAnnotated(Extension.class);
         for (Class extension : extensions) {
-            addExtensionToMap(extension, siddhiExtensionsMap);
+            addExtensionToMap(extension, siddhiExtensionsMap, extensionHolderMap);
         }
 
         // load extensions related to incremental aggregation
@@ -96,8 +151,11 @@ public class SiddhiExtensionLoader {
      *
      * @param extensionClass      extension class
      * @param siddhiExtensionsMap reference map for the Siddhi extension
+     * @param extensionHolderMap reference map for the Siddhi extension holder
      */
-    private static void addExtensionToMap(Class extensionClass, Map<String, Class> siddhiExtensionsMap) {
+    private static void addExtensionToMap(Class extensionClass, Map<String, Class> siddhiExtensionsMap,
+                                          ConcurrentHashMap<Class, AbstractExtensionHolder>
+                                                  extensionHolderMap) {
         Extension siddhiExtensionAnnotation = (Extension) extensionClass.getAnnotation(Extension.class);
         if (siddhiExtensionAnnotation != null) {
             if (!siddhiExtensionAnnotation.name().isEmpty()) {
@@ -105,7 +163,14 @@ public class SiddhiExtensionLoader {
                 if (!siddhiExtensionAnnotation.namespace().isEmpty()) {
                     String key = siddhiExtensionAnnotation.namespace() + SiddhiConstants.EXTENSION_SEPARATOR +
                             siddhiExtensionAnnotation.name();
-                    previousClass = siddhiExtensionsMap.put(key, extensionClass);
+                    Class existingValue = siddhiExtensionsMap.get(key);
+                    if (existingValue == null) {
+                        previousClass = siddhiExtensionsMap.put(key, extensionClass);
+                        for (Class clazz : extensionNameSpaceList) {
+                            putToExtensionHolderMap(clazz, extensionClass, key,
+                                    extensionHolderMap);
+                        }
+                    }
                     if (previousClass != null) {
                         log.warn("Dropping extension '" + previousClass + "' as '" + extensionClass + "' is " +
                                 "loaded with the same namespace and name '" +
@@ -125,6 +190,31 @@ public class SiddhiExtensionLoader {
         } else {
             log.error("Unable to load extension " + extensionClass.getName() + ", empty name element given in " +
                     "Extension annotation.");
+        }
+    }
+
+    /**
+     * Adding extensions to Siddhi siddhiExtensionsHolderMap.
+     *
+     * @param extensionSuperClass              extension super class (eg:Source)
+     * @param extension                        extension class (eg:HttpSource)
+     * @param extensionKey                     fully qualified extension name (namespace:extensionName)
+     * @param extensionHolderConcurrentHashMap reference map for the Siddhi extension holder
+     */
+    private static void putToExtensionHolderMap(
+            Class extensionSuperClass, Class extension, String extensionKey,
+            ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderConcurrentHashMap) {
+        if (extensionSuperClass.isAssignableFrom(extension)) {
+            AbstractExtensionHolder extensionHolder = extensionHolderConcurrentHashMap.get(extensionSuperClass);
+            if (extensionHolder != null) {
+                if (extensionHolder.getExtension(extensionKey) != null) {
+                    log.error("Extension class " + extension.getName() + " not loaded, as there is already an" +
+                            " matching extension '" + extensionKey + "' implemented as " + extensionHolder
+                            .getExtension(extensionKey).getName());
+                } else {
+                    extensionHolder.addExtension(extensionKey, extension);
+                }
+            }
         }
     }
 
@@ -155,9 +245,12 @@ public class SiddhiExtensionLoader {
 
         private Map<Class, Integer> bundleExtensions = new HashMap<Class, Integer>();
         private Map<String, Class> siddhiExtensionsMap;
+        private ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderConcurrentHashMap;
 
-        ExtensionBundleListener(Map<String, Class> siddhiExtensionsMap) {
+        ExtensionBundleListener(Map<String, Class> siddhiExtensionsMap,
+                                ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderConcurrentHashMap) {
             this.siddhiExtensionsMap = siddhiExtensionsMap;
+            this.extensionHolderConcurrentHashMap = extensionHolderConcurrentHashMap;
         }
 
         @Override
@@ -173,7 +266,7 @@ public class SiddhiExtensionLoader {
             ClassLoader classLoader = bundle.adapt(BundleWiring.class).getClassLoader();
             Iterable<Class<?>> extensions = ClassIndex.getAnnotated(Extension.class, classLoader);
             for (Class extension : extensions) {
-                addExtensionToMap(extension, siddhiExtensionsMap);
+                addExtensionToMap(extension, siddhiExtensionsMap, extensionHolderConcurrentHashMap);
                 bundleExtensions.put(extension, (int) bundle.getBundleId());
             }
         }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/AbstractExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/AbstractExtensionHolder.java
@@ -74,4 +74,10 @@ public abstract class AbstractExtensionHolder {
         }
     }
 
+    public void removeExtension(String extensionKey) {
+        if (!extensionKey.isEmpty()) {
+            extensionMap.remove(extensionKey);
+        }
+    }
+
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/AbstractExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/AbstractExtensionHolder.java
@@ -61,4 +61,17 @@ public abstract class AbstractExtensionHolder {
         }
     }
 
+    public Class getExtension(String extensionKey) {
+        if (!extensionKey.isEmpty()) {
+            return extensionMap.get(extensionKey);
+        }
+        return null;
+    }
+
+    public void addExtension(String extensionKey, Class clazz) {
+        if (!extensionKey.isEmpty()) {
+            extensionMap.put(extensionKey, clazz);
+        }
+    }
+
 }


### PR DESCRIPTION
## Purpose
>  Siddhi extensions are sometimes not picked by Siddhi Manager while creating Siddhi Runtime. This is because, the latter picked extensions by the ExtensionListenere will not be updated at the secondary extension map(extensionHolderMap).

## Approach
> When an extension is picked/removed by extensionListener update it at the extensionHolderMap as well.
