### PR TITLE
Support mapping transport properties to any data type.

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/AttributeMapping.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/AttributeMapping.java
@@ -18,6 +18,8 @@
 
 package io.siddhi.core.stream.input.source;
 
+import io.siddhi.query.api.definition.Attribute;
+
 /**
  * Holder object to store mapping information for a given Siddhi Attribute
  * {@link io.siddhi.query.api.definition.Attribute}
@@ -25,12 +27,14 @@ package io.siddhi.core.stream.input.source;
 public class AttributeMapping {
     protected String name;
     protected int position;
+    protected Attribute.Type type;
     private String mapping = null;
 
-    public AttributeMapping(String name, int position, String mapping) {
+    public AttributeMapping(String name, int position, String mapping, Attribute.Type type) {
         this.name = name;
         this.position = position;
         this.mapping = mapping;
+        this.type = type;
     }
 
     public String getMapping() {
@@ -45,11 +49,17 @@ public class AttributeMapping {
         return position;
     }
 
+    public Attribute.Type getType() {
+        return type;
+    }
+
     @Override
     public String toString() {
         return "AttributeMapping{" +
                 "name='" + name + '\'' +
+                ", position=" + position +
                 ", mapping='" + mapping + '\'' +
+                ", type=" + type +
                 '}';
     }
 
@@ -58,7 +68,7 @@ public class AttributeMapping {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof AttributeMapping)) {
             return false;
         }
 
@@ -70,7 +80,10 @@ public class AttributeMapping {
         if (name != null ? !name.equals(that.name) : that.name != null) {
             return false;
         }
-        return mapping != null ? mapping.equals(that.mapping) : that.mapping == null;
+        if (mapping != null ? !mapping.equals(that.mapping) : that.mapping != null) {
+            return false;
+        }
+        return type == that.type;
     }
 
     @Override
@@ -78,6 +91,7 @@ public class AttributeMapping {
         int result = name != null ? name.hashCode() : 0;
         result = 31 * result + position;
         result = 31 * result + (mapping != null ? mapping.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
         return result;
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/InputEventHandler.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/InputEventHandler.java
@@ -107,7 +107,8 @@ public class InputEventHandler {
                 }
                 for (int i = 0; i < transportMapping.size(); i++) {
                     AttributeMapping attributeMapping = transportMapping.get(i);
-                    event.getData()[attributeMapping.getPosition()] = transportProperties[i];
+                    event.getData()[attributeMapping.getPosition()] = AttributeConverter.getPropertyValue(
+                            transportProperties[i], attributeMapping.getType());
                 }
             }
             inputEventHandlerCallback.sendEvents(events, transportSyncProperties);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/InputEventHandler.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/InputEventHandler.java
@@ -21,6 +21,7 @@ package io.siddhi.core.stream.input.source;
 import io.siddhi.core.config.SiddhiAppContext;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.util.AttributeConverter;
 import io.siddhi.core.util.ExceptionUtil;
 import io.siddhi.core.util.statistics.LatencyTracker;
 import io.siddhi.core.util.statistics.metrics.Level;
@@ -36,7 +37,7 @@ public class InputEventHandler {
 
     private static final Logger LOG = Logger.getLogger(InputEventHandler.class);
 
-    private final ThreadLocal<String[]> trpProperties;
+    private final ThreadLocal<Object[]> trpProperties;
     private final TimestampGenerator timestampGenerator;
     private ThreadLocal<String[]> trpSyncProperties;
     private String sourceType;
@@ -47,7 +48,7 @@ public class InputEventHandler {
     private InputEventHandlerCallback inputEventHandlerCallback;
 
     InputEventHandler(InputHandler inputHandler, List<AttributeMapping> transportMapping,
-                      ThreadLocal<String[]> trpProperties, ThreadLocal<String[]> trpSyncProperties, String sourceType,
+                      ThreadLocal<Object[]> trpProperties, ThreadLocal<String[]> trpSyncProperties, String sourceType,
                       LatencyTracker latencyTracker, SiddhiAppContext siddhiAppContext,
                       InputEventHandlerCallback inputEventHandlerCallback) {
         this.inputHandler = inputHandler;
@@ -66,7 +67,7 @@ public class InputEventHandler {
             if (latencyTracker != null && Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
                 latencyTracker.markOut();
             }
-            String[] transportProperties = trpProperties.get();
+            Object[] transportProperties = trpProperties.get();
             trpProperties.remove();
             String[] transportSyncProperties = trpSyncProperties.get();
             trpSyncProperties.remove();
@@ -76,7 +77,8 @@ public class InputEventHandler {
             }
             for (int i = 0; i < transportMapping.size(); i++) {
                 AttributeMapping attributeMapping = transportMapping.get(i);
-                event.getData()[attributeMapping.getPosition()] = transportProperties[i];
+                event.getData()[attributeMapping.getPosition()] = AttributeConverter.getPropertyValue(
+                        transportProperties[i], attributeMapping.getType());
             }
             inputEventHandlerCallback.sendEvent(event, transportSyncProperties);
         } catch (RuntimeException e) {
@@ -94,7 +96,7 @@ public class InputEventHandler {
             if (latencyTracker != null && Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
                 latencyTracker.markOut();
             }
-            String[] transportProperties = trpProperties.get();
+            Object[] transportProperties = trpProperties.get();
             trpProperties.remove();
             String[] transportSyncProperties = trpSyncProperties.get();
             trpSyncProperties.remove();

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/SourceEventListener.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/SourceEventListener.java
@@ -28,7 +28,13 @@ public interface SourceEventListener {
 
     StreamDefinition getStreamDefinition();
 
+    void onEvent(Object eventObject, Object[] transportProperties);
+
+    @Deprecated
     void onEvent(Object eventObject, String[] transportProperties);
 
+    void onEvent(Object eventObject, Object[] transportProperties, String[] transportSyncProperties);
+
+    @Deprecated
     void onEvent(Object eventObject, String[] transportProperties, String[] transportSyncProperties);
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/SourceMapper.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/SourceMapper.java
@@ -39,7 +39,7 @@ import java.util.List;
 public abstract class SourceMapper implements SourceEventListener {
 
     private static final Logger log = Logger.getLogger(SourceMapper.class);
-    private final ThreadLocal<String[]> trpProperties = new ThreadLocal<>();
+    private final ThreadLocal<Object[]> trpProperties = new ThreadLocal<>();
     private final ThreadLocal<String[]> trpSyncProperties = new ThreadLocal<>();
     protected String sourceType;
     protected OptionHolder sourceOptionHolder;
@@ -115,15 +115,37 @@ public abstract class SourceMapper implements SourceEventListener {
     }
 
     public final void onEvent(Object eventObject, String[] transportProperties) {
+        Object[] transportPropertyObjects = convertToObjectArray(transportProperties);
+        onEvent(eventObject, transportPropertyObjects, null);
+    }
+
+    public final void onEvent(Object eventObject, Object[] transportProperties) {
         onEvent(eventObject, transportProperties, null);
     }
 
     public final void onEvent(Object eventObject, String[] transportProperties, String[] transportSyncProperties) {
+        Object[] transportPropertyObjects = convertToObjectArray(transportProperties);
+        onEvent(eventObject, transportPropertyObjects, transportSyncProperties);
 
+    }
+
+    private Object[] convertToObjectArray(String[] transportProperties) {
+        Object[] transportPropertyObjects = null;
+        if (transportProperties != null) {
+            transportPropertyObjects = new Object[transportProperties.length];
+            for (int i = 0, transportPropertiesLength = transportProperties.length; i < transportPropertiesLength; i++) {
+                String transportProperty = transportProperties[i];
+                transportPropertyObjects[i] = transportProperty;
+            }
+        }
+        return transportPropertyObjects;
+    }
+
+    public final void onEvent(Object eventObject, Object[] transportProperties, String[] transportSyncProperties) {
         try {
             if (eventObject != null) {
                 if (!allowNullInTransportProperties() && transportProperties != null) {
-                    for (String property : transportProperties) {
+                    for (Object property : transportProperties) {
                         if (property == null) {
                             log.error("Dropping event " + eventObject.toString() + " belonging to stream " +
                                     sourceHandler.getInputHandler().getStreamId()

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/SourceMapper.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/SourceMapper.java
@@ -133,7 +133,8 @@ public abstract class SourceMapper implements SourceEventListener {
         Object[] transportPropertyObjects = null;
         if (transportProperties != null) {
             transportPropertyObjects = new Object[transportProperties.length];
-            for (int i = 0, transportPropertiesLength = transportProperties.length; i < transportPropertiesLength; i++) {
+            for (int i = 0, transportPropertiesLength = transportProperties.length;
+                 i < transportPropertiesLength; i++) {
                 String transportProperty = transportProperties[i];
                 transportPropertyObjects[i] = transportProperty;
             }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/AttributeConverter.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/AttributeConverter.java
@@ -81,7 +81,7 @@ public class AttributeConverter {
                 if (propertyValue instanceof Double) {
                     return propertyValue;
                 } else if (propertyValue instanceof Float) {
-                    return new Double((Float) propertyValue);
+                    return Double.valueOf((Float) propertyValue);
                 } else if (propertyValue instanceof String) {
                     return Double.parseDouble((String) propertyValue);
                 } else {
@@ -111,7 +111,7 @@ public class AttributeConverter {
                 }
             case LONG:
                 if (propertyValue instanceof Integer) {
-                    return new Long((Integer) propertyValue);
+                    return Long.valueOf((Integer) propertyValue);
                 } else if (propertyValue instanceof Long) {
                     return propertyValue;
                 } else if (propertyValue instanceof String) {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/AttributeConverter.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/AttributeConverter.java
@@ -35,7 +35,7 @@ public class AttributeConverter {
      * @param attributeType the desired data type
      * @return the converted object
      */
-    public Object getPropertyValue(String propertyValue, Attribute.Type attributeType) {
+    public static Object getPropertyValue(String propertyValue, Attribute.Type attributeType) {
         switch (attributeType) {
             case BOOL:
                 return Boolean.parseBoolean(propertyValue);
@@ -48,6 +48,82 @@ public class AttributeConverter {
             case LONG:
                 return Long.parseLong(propertyValue);
             case STRING:
+                return propertyValue;
+            case OBJECT:
+                return propertyValue;
+            default:
+                throw new SiddhiAppRuntimeException("No supported mapping for '" + propertyValue +
+                        "' with class '" + propertyValue.getClass().getName() + "' to attribute type '" +
+                        attributeType + "'.");
+        }
+    }
+
+    /**
+     * Convert the given object to the given type.
+     *
+     * @param propertyValue the actual object
+     * @param attributeType the desired data type
+     * @return the converted object
+     */
+    public static Object getPropertyValue(Object propertyValue, Attribute.Type attributeType) {
+        switch (attributeType) {
+            case BOOL:
+                if (propertyValue instanceof Boolean) {
+                    return propertyValue;
+                } else if (propertyValue instanceof String) {
+                    return Boolean.parseBoolean((String) propertyValue);
+                } else {
+                    throw new SiddhiAppRuntimeException("No supported mapping for '" + propertyValue +
+                            "' with class '" + propertyValue.getClass().getName() + "' to attribute type '" +
+                            attributeType + "'.");
+                }
+            case DOUBLE:
+                if (propertyValue instanceof Double) {
+                    return propertyValue;
+                } else if (propertyValue instanceof Float) {
+                    return new Double((Float) propertyValue);
+                } else if (propertyValue instanceof String) {
+                    return Double.parseDouble((String) propertyValue);
+                } else {
+                    throw new SiddhiAppRuntimeException("No supported mapping for '" + propertyValue +
+                            "' with class '" + propertyValue.getClass().getName() + "' to attribute type '" +
+                            attributeType + "'.");
+                }
+            case FLOAT:
+                if (propertyValue instanceof Float) {
+                    return propertyValue;
+                } else if (propertyValue instanceof String) {
+                    return Float.parseFloat((String) propertyValue);
+                } else {
+                    throw new SiddhiAppRuntimeException("No supported mapping for '" + propertyValue +
+                            "' with class '" + propertyValue.getClass().getName() + "' to attribute type '" +
+                            attributeType + "'.");
+                }
+            case INT:
+                if (propertyValue instanceof Integer) {
+                    return propertyValue;
+                } else if (propertyValue instanceof String) {
+                    return Integer.parseInt((String) propertyValue);
+                } else {
+                    throw new SiddhiAppRuntimeException("No supported mapping for '" + propertyValue +
+                            "' with class '" + propertyValue.getClass().getName() + "' to attribute type '" +
+                            attributeType + "'.");
+                }
+            case LONG:
+                if (propertyValue instanceof Integer) {
+                    return new Long((Integer) propertyValue);
+                } else if (propertyValue instanceof Long) {
+                    return propertyValue;
+                } else if (propertyValue instanceof String) {
+                    return Long.parseLong((String) propertyValue);
+                } else {
+                    throw new SiddhiAppRuntimeException("No supported mapping for '" + propertyValue +
+                            "' with class '" + propertyValue.getClass().getName() + "' to attribute type '" +
+                            attributeType + "'.");
+                }
+            case STRING:
+                return propertyValue.toString();
+            case OBJECT:
                 return propertyValue;
             default:
                 throw new SiddhiAppRuntimeException("Attribute type: " + attributeType + " not supported by XML " +

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/AttributeConverter.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/AttributeConverter.java
@@ -27,7 +27,6 @@ import io.siddhi.query.api.definition.Attribute;
  */
 public class AttributeConverter {
 
-
     /**
      * Convert the given object to the given type.
      *
@@ -35,7 +34,7 @@ public class AttributeConverter {
      * @param attributeType the desired data type
      * @return the converted object
      */
-    public static Object getPropertyValue(String propertyValue, Attribute.Type attributeType) {
+    public Object getPropertyValue(String propertyValue, Attribute.Type attributeType) {
         switch (attributeType) {
             case BOOL:
                 return Boolean.parseBoolean(propertyValue);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/helper/DefinitionParserHelper.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/helper/DefinitionParserHelper.java
@@ -753,9 +753,10 @@ public class DefinitionParserHelper {
         String mapping = elementMap.get(attribute.getName()).trim();
         if (mapping.startsWith("trp:")) {
             attributesHolder.transportMappings.add(new AttributeMapping(attribute.getName(), i, mapping
-                    .substring(4)));
+                    .substring(4), attribute.getType()));
         } else {
-            attributesHolder.payloadMappings.add(new AttributeMapping(attribute.getName(), i, mapping));
+            attributesHolder.payloadMappings.add(new AttributeMapping(attribute.getName(), i, mapping,
+                    attribute.getType()));
         }
     }
 

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/InMemoryTransportTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/InMemoryTransportTestCase.java
@@ -824,11 +824,11 @@ public class InMemoryTransportTestCase {
 
         String streams = "" +
                 "@app:name('TestSiddhiApp')" +
-                "@source(type='testTrpInMemory', topic='Foo', prop1='hi', prop2='test', " +
+                "@source(type='testTrpInMemory', topic='Foo', prop1='hi', prop2='7.5', " +
                 "   @map(type='testTrp', @attributes(symbol='trp:symbol'," +
                 "        volume='2',price='trp:price'))) " +
-                "define stream FooStream (symbol string, price string, volume long); " +
-                "define stream BarStream (symbol string, price string, volume long); ";
+                "define stream FooStream (symbol string, price double, volume long); " +
+                "define stream BarStream (symbol string, price double, volume long); ";
 
         String query = "" +
                 "from FooStream " +
@@ -844,14 +844,14 @@ public class InMemoryTransportTestCase {
                 EventPrinter.print(events);
                 wso2Count.incrementAndGet();
                 for (Event event : events) {
-                    AssertJUnit.assertArrayEquals(event.getData(), new Object[]{"hi", "test", 100L});
+                    AssertJUnit.assertArrayEquals(event.getData(), new Object[]{"hi", 7.5, 100L});
                 }
             }
         });
         siddhiAppRuntime.start();
-        InMemoryBroker.publish("Foo", new Event(System.currentTimeMillis(), new Object[]{"WSO2", "in", 100L}));
-        InMemoryBroker.publish("Foo", new Event(System.currentTimeMillis(), new Object[]{"IBM", "in", 100L}));
-        InMemoryBroker.publish("Foo", new Event(System.currentTimeMillis(), new Object[]{"WSO2", "in", 100L}));
+        InMemoryBroker.publish("Foo", new Event(System.currentTimeMillis(), new Object[]{"WSO2", 5.5, 100L}));
+        InMemoryBroker.publish("Foo", new Event(System.currentTimeMillis(), new Object[]{"IBM", 5.5, 100L}));
+        InMemoryBroker.publish("Foo", new Event(System.currentTimeMillis(), new Object[]{"WSO2", 5.5, 100L}));
         Thread.sleep(100);
 
         //assert event count

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/transport/InMemoryTransportTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/transport/InMemoryTransportTestCase.java
@@ -1489,6 +1489,7 @@ public class InMemoryTransportTestCase {
                 "per perValue " +
                 "select b.symbol1, b.totalPrice " +
                 "group by b.symbol1 " +
+                "order by b.symbol1 " +
                 "insert into OutputStream ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(app);
@@ -1498,10 +1499,10 @@ public class InMemoryTransportTestCase {
             public void receive(Event[] events) {
                 EventPrinter.print(events);
                 Assert.assertEquals(events.length, 4);
-                Assert.assertEquals(events[0].getData(1), 4.0);
-                Assert.assertEquals(events[1].getData(1), 120.0);
-                Assert.assertEquals(events[2].getData(1), 4.0);
-                Assert.assertEquals(events[3].getData(1), 120.0);
+                Assert.assertEquals(events[0].getData(1), 120.0);
+                Assert.assertEquals(events[1].getData(1), 4.0);
+                Assert.assertEquals(events[2].getData(1), 120.0);
+                Assert.assertEquals(events[3].getData(1), 4.0);
 
             }
 


### PR DESCRIPTION
## Purpose
> Support mapping transport properties to any data type.
> Fixes https://github.com/siddhi-io/siddhi/issues/1557

## Goals
> Currently, only String[] is supported as transport properties, with this fix Object[] can be passed as transport properties.
> This fix also supports converting the transport properties into the mapped attribute type.

## Release note
> Support transport properties to be mapped to the attribute type.

