### PR TITLE
Update central repo for secure communication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -874,7 +874,7 @@
             <id>central</id>
             <name>Maven Repository Switchboard</name>
             <layout>default</layout>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
## Purpose
> Effective from January 15, 2020, The Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS.
Source: https://support.sonatype.com/hc/en-us/articles/360041287334
