### PR TITLE
Allow for unconditional deletes

### DIFF
--- a/modules/siddhi-query-compiler/src/main/antlr4/io/siddhi/query/compiler/SiddhiQL.g4
+++ b/modules/siddhi-query-compiler/src/main/antlr4/io/siddhi/query/compiler/SiddhiQL.g4
@@ -394,14 +394,14 @@ offset
 
 query_output
     :INSERT output_event_type? INTO target
-    |DELETE target (FOR output_event_type)? ON expression
+    |DELETE target (FOR output_event_type)? (ON expression)?
     |UPDATE OR INSERT INTO target (FOR output_event_type)? set_clause? ON expression
     |UPDATE target (FOR output_event_type)? set_clause? ON expression
     |RETURN output_event_type?
     ;
 
 store_query_output
-    :DELETE target ON expression
+    :DELETE target (ON expression)?
     |UPDATE target set_clause? ON expression
     ;
 

--- a/modules/siddhi-query-compiler/src/main/java/io/siddhi/query/compiler/internal/SiddhiQLBaseVisitorImpl.java
+++ b/modules/siddhi-query-compiler/src/main/java/io/siddhi/query/compiler/internal/SiddhiQLBaseVisitorImpl.java
@@ -1720,14 +1720,17 @@ public class SiddhiQLBaseVisitorImpl extends SiddhiQLBaseVisitor {
             if (source.isInnerStream || source.isFaultStream) {
                 throw newSiddhiParserException(ctx, "DELETE can be only used with Tables!");
             }
+            Expression expression = null;
+            if (ctx.expression() != null) {
+                expression = (Expression) visit(ctx.expression());
+            }
             if (ctx.output_event_type() != null) {
                 OutputStream outputStream = new DeleteStream(source.streamId,
-                        (OutputStream.OutputEventType) visit(ctx.output_event_type()),
-                        (Expression) visit(ctx.expression()));
+                        (OutputStream.OutputEventType) visit(ctx.output_event_type()), expression);
                 populateQueryContext(outputStream, ctx);
                 return outputStream;
             } else {
-                OutputStream outputStream = new DeleteStream(source.streamId, (Expression) visit(ctx.expression()));
+                OutputStream outputStream = new DeleteStream(source.streamId, expression);
                 populateQueryContext(outputStream, ctx);
                 return outputStream;
             }
@@ -1797,7 +1800,11 @@ public class SiddhiQLBaseVisitorImpl extends SiddhiQLBaseVisitor {
             if (source.isInnerStream || source.isFaultStream) {
                 throw newSiddhiParserException(ctx, "DELETE can be only used with Tables!");
             }
-            OutputStream outputStream = new DeleteStream(source.streamId, (Expression) visit(ctx.expression()));
+            Expression expression = null;
+            if (ctx.expression() != null) {
+                expression = (Expression) visit(ctx.expression());
+            }
+            OutputStream outputStream = new DeleteStream(source.streamId, expression);
             populateQueryContext(outputStream, ctx);
             return outputStream;
         } else if (ctx.UPDATE() != null) {


### PR DESCRIPTION
## Purpose
Resolve #1624, making delete expression optional.

## Goals
On delete statements, visitor implementation needs to first check whether there is an expression or not, since, according to the documentation, it is optional:

>When specifying the condition, the table attributes should always be referred with the table name, and and **when a condition is not defined, all the events in the table will be deleted**.

## Approach
Before visiting the expression nodes, check whether expression has been specified in the first place.
