### PR TITLE
Make time zone configurable in aggregation

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/AggregationRuntime.java
@@ -109,6 +109,7 @@ public class AggregationRuntime implements MemoryCalculable {
     private ThroughputTracker throughputTrackerFind;
 
     private boolean isFirstEventArrived;
+    private String timeZone;
 
     public AggregationRuntime(AggregationDefinition aggregationDefinition, boolean isProcessingOnExternalTime,
                               boolean isDistributed, List<TimePeriod.Duration> incrementalDurations,
@@ -124,8 +125,9 @@ public class AggregationRuntime implements MemoryCalculable {
                               List<Expression> finalBaseExpressionList, IncrementalDataPurger incrementalDataPurger,
                               IncrementalExecutorsInitialiser incrementalExecutorInitialiser,
                               SingleStreamRuntime singleStreamRuntime, MetaStreamEvent tableMetaStreamEvent,
-                              LatencyTracker latencyTrackerFind, ThroughputTracker throughputTrackerFind) {
-
+                              LatencyTracker latencyTrackerFind, ThroughputTracker throughputTrackerFind,
+                              String timeZone) {
+        this.timeZone = timeZone;
         this.aggregationDefinition = aggregationDefinition;
         this.isProcessingOnExternalTime = isProcessingOnExternalTime;
         this.isDistributed = isDistributed;
@@ -343,7 +345,7 @@ public class AggregationRuntime implements MemoryCalculable {
             }
             return ((IncrementalAggregateCompileCondition) compiledCondition).find(matchingEvent,
                     incrementalExecutorMap, aggregateProcessingExecutorsMap, groupByKeyGeneratorMap,
-                    shouldUpdateTimestamp);
+                    shouldUpdateTimestamp, timeZone);
 
         } finally {
             SnapshotService.getSkipStateStorageThreadLocal().set(null);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalDataAggregator.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalDataAggregator.java
@@ -56,13 +56,14 @@ public class IncrementalDataAggregator {
     private final StreamEvent resetEvent;
     private final StreamEventFactory streamEventFactory;
     private ExpressionExecutor shouldUpdateTimestamp;
+    private String timeZone;
 
     public IncrementalDataAggregator(List<TimePeriod.Duration> incrementalDurations,
                                      TimePeriod.Duration durationToAggregate, long oldestEventTimestamp,
                                      List<ExpressionExecutor> baseExecutorsForFind,
                                      ExpressionExecutor shouldUpdateTimestamp, boolean groupBy,
-                                     MetaStreamEvent metaStreamEvent) {
-
+                                     MetaStreamEvent metaStreamEvent, String timeZone) {
+        this.timeZone = timeZone;
         this.incrementalDurations = incrementalDurations;
         this.durationToAggregate = durationToAggregate;
 
@@ -93,7 +94,7 @@ public class IncrementalDataAggregator {
             Map<String, StreamEvent> groupedByEvents = aBaseIncrementalValueStore.getGroupedByEvents();
             for (Map.Entry<String, StreamEvent> eventEntry : groupedByEvents.entrySet()) {
                 long startTimeOfAggregates = IncrementalTimeConverterUtil.getStartTimeOfAggregates(
-                        eventEntry.getValue().getTimestamp(), durationToAggregate);
+                        eventEntry.getValue().getTimestamp(), durationToAggregate, timeZone);
                 String groupByKey = eventEntry.getKey() + "-" + startTimeOfAggregates;
                 synchronized (this) {
                     groupByKeys.add(groupByKey);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalExecutorsInitialiser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalExecutorsInitialiser.java
@@ -61,6 +61,7 @@ public class IncrementalExecutorsInitialiser {
     private final Map<String, Table> tableMap;
     private final Map<String, Window> windowMap;
     private final Map<String, AggregationRuntime> aggregationMap;
+    private String timeZone;
 
     private boolean isInitialised;
 
@@ -70,8 +71,8 @@ public class IncrementalExecutorsInitialiser {
                                            boolean isDistributed, String shardId, SiddhiAppContext siddhiAppContext,
                                            MetaStreamEvent metaStreamEvent, Map<String, Table> tableMap,
                                            Map<String, Window> windowMap,
-                                           Map<String, AggregationRuntime> aggregationMap) {
-
+                                           Map<String, AggregationRuntime> aggregationMap, String timeZone) {
+        this.timeZone = timeZone;
         this.incrementalDurations = incrementalDurations;
         this.aggregationTables = aggregationTables;
         this.incrementalExecutorMap = incrementalExecutorMap;
@@ -109,7 +110,7 @@ public class IncrementalExecutorsInitialiser {
         if (events != null) {
             Long lastData = (Long) events[events.length - 1].getData(0);
             endOFLatestEventTimestamp = IncrementalTimeConverterUtil
-                    .getNextEmitTime(lastData, incrementalDurations.get(incrementalDurations.size() - 1), null);
+                    .getNextEmitTime(lastData, incrementalDurations.get(incrementalDurations.size() - 1), timeZone);
         }
 
         for (int i = incrementalDurations.size() - 1; i > 0; i--) {
@@ -132,7 +133,7 @@ public class IncrementalExecutorsInitialiser {
             if (events != null) {
                 long referenceToNextLatestEvent = (Long) events[events.length - 1].getData(0);
                 endOFLatestEventTimestamp = IncrementalTimeConverterUtil
-                        .getNextEmitTime(referenceToNextLatestEvent, incrementalDurations.get(i - 1), null);
+                        .getNextEmitTime(referenceToNextLatestEvent, incrementalDurations.get(i - 1), timeZone);
 
                 ComplexEventChunk<StreamEvent> complexEventChunk = new ComplexEventChunk<>();
                 for (Event event : events) {
@@ -146,7 +147,7 @@ public class IncrementalExecutorsInitialiser {
                     TimePeriod.Duration rootDuration = incrementalDurations.get(0);
                     IncrementalExecutor rootIncrementalExecutor = incrementalExecutorMap.get(rootDuration);
                     long emitTimeOfLatestEventInTable = IncrementalTimeConverterUtil.getNextEmitTime(
-                            referenceToNextLatestEvent, rootDuration, null);
+                            referenceToNextLatestEvent, rootDuration, timeZone);
 
                     rootIncrementalExecutor.setEmitTime(emitTimeOfLatestEventInTable);
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/executor/incremental/IncrementalAggregateBaseTimeFunctionExecutor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/executor/incremental/IncrementalAggregateBaseTimeFunctionExecutor.java
@@ -23,6 +23,7 @@ import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.IncrementalTimeConverterUtil;
+import io.siddhi.core.util.SiddhiConstants;
 import io.siddhi.core.util.config.ConfigReader;
 import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
@@ -35,6 +36,7 @@ import io.siddhi.query.api.exception.SiddhiAppValidationException;
  * This is important when retrieving incremental aggregate values by specifying a time range with 'within' clause.
  */
 public class IncrementalAggregateBaseTimeFunctionExecutor extends FunctionExecutor {
+    private String timeZone;
 
     @Override
     protected StateFactory init(ExpressionExecutor[] attributeExpressionExecutors, ConfigReader configReader,
@@ -47,6 +49,11 @@ public class IncrementalAggregateBaseTimeFunctionExecutor extends FunctionExecut
             throw new SiddhiAppValidationException("Second argument of " +
                     "incrementalAggregator:getAggregationStartTime() function accepts should be of type 'STRING', " +
                     "but found '" + attributeExpressionExecutors[1].getReturnType() + "'.");
+        }
+        this.timeZone = siddhiQueryContext.getSiddhiContext().getConfigManager().extractProperty(SiddhiConstants
+                .AGG_TIME_ZONE);
+        if (timeZone == null) {
+            this.timeZone = SiddhiConstants.AGG_TIME_ZONE_DEFAULT;
         }
         return null;
     }
@@ -80,7 +87,7 @@ public class IncrementalAggregateBaseTimeFunctionExecutor extends FunctionExecut
                 throw new SiddhiAppRuntimeException("Duration '" + durationName + "' used for " +
                         "incrementalAggregator:aggregateBaseTime() is invalid.");
         }
-        return IncrementalTimeConverterUtil.getStartTimeOfAggregates(time, duration);
+        return IncrementalTimeConverterUtil.getStartTimeOfAggregates(time, duration, timeZone);
     }
 
     @Override

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiConstants.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiConstants.java
@@ -141,6 +141,8 @@ public final class SiddhiConstants {
     public static final String AGG_EXTERNAL_TIMESTAMP_COL = "AGG_EVENT_TIMESTAMP";
     public static final String AGG_LAST_TIMESTAMP_COL = "AGG_LAST_EVENT_TIMESTAMP";
     public static final String AGG_SHARD_ID_COL = "SHARD_ID";
+    public static final String AGG_TIME_ZONE = "aggTimeZone";
+    public static final String AGG_TIME_ZONE_DEFAULT = "GMT";
 
     public static final String REPETITIVE_PARAMETER_NOTATION = "...";
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/collection/operator/IncrementalAggregateCompileCondition.java
@@ -144,7 +144,7 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
                             Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap,
                             Map<TimePeriod.Duration, List<ExpressionExecutor>> aggregateProcessingExecutorsMap,
                             Map<TimePeriod.Duration, GroupByKeyGenerator> groupByKeyGeneratorMap,
-                            ExpressionExecutor shouldUpdateTimestamp) {
+                            ExpressionExecutor shouldUpdateTimestamp, String timeZone) {
 
         ComplexEventChunk<StreamEvent> complexEventChunkToHoldWithinMatches = new ComplexEventChunk<>();
 
@@ -242,7 +242,7 @@ public class IncrementalAggregateCompileCondition implements CompiledCondition {
                 IncrementalDataAggregator incrementalDataAggregator = new IncrementalDataAggregator(
                         incrementalDurations, perValue, oldestInMemoryEventTimestamp,
                         aggregateProcessingExecutorsMap.get(rootDuration), shouldUpdateTimestamp,
-                        groupByKeyGeneratorMap.get(rootDuration) != null, tableMetaStreamEvent);
+                        groupByKeyGeneratorMap.get(rootDuration) != null, tableMetaStreamEvent, timeZone);
                 ComplexEventChunk<StreamEvent> aggregatedInMemoryEventChunk;
                 // Aggregate in-memory data and create an event chunk out of it
                 aggregatedInMemoryEventChunk = incrementalDataAggregator.aggregateInMemoryData(incrementalExecutorMap);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
@@ -370,7 +370,7 @@ public class AggregationParser {
             //Recreate in-memory data from tables
             IncrementalExecutorsInitialiser incrementalExecutorsInitialiser = new IncrementalExecutorsInitialiser(
                     incrementalDurations, aggregationTables, incrementalExecutorMap, isDistributed, shardId,
-                    siddhiAppContext, processedMetaStreamEvent, tableMap, windowMap, aggregationMap);
+                    siddhiAppContext, processedMetaStreamEvent, tableMap, windowMap, aggregationMap, timeZone);
 
             IncrementalExecutor rootIncrementalExecutor = incrementalExecutorMap.get(incrementalDurations.get(0));
             rootIncrementalExecutor.setScheduler(scheduler);


### PR DESCRIPTION
## Purpose
The aggregation time period follows GMT timezone regardless of the user time zone before this feature. This may be inconvenient for users who want aggregations to happen according to their local timezones. This change makes time zone a configurable parameter in deployment.yaml as follows,

siddhi:
  properties:
    aggTimeZone: Asia/Singapore 

## Automation tests
 - 10 unit tests are written

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> MacOS Catalina 10.15.3 Java 1.8.0_201
 
