### PR TITLE
Add a counter to count events after mapping

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/InputEventHandler.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/InputEventHandler.java
@@ -46,6 +46,7 @@ public class InputEventHandler {
     private InputHandler inputHandler;
     private List<AttributeMapping> transportMapping;
     private InputEventHandlerCallback inputEventHandlerCallback;
+    private long eventCount;
 
     InputEventHandler(InputHandler inputHandler, List<AttributeMapping> transportMapping,
                       ThreadLocal<Object[]> trpProperties, ThreadLocal<String[]> trpSyncProperties, String sourceType,
@@ -81,6 +82,7 @@ public class InputEventHandler {
                         transportProperties[i], attributeMapping.getType());
             }
             inputEventHandlerCallback.sendEvent(event, transportSyncProperties);
+            eventCount++;
         } catch (RuntimeException e) {
             LOG.error(ExceptionUtil.getMessageWithContext(e, siddhiAppContext) +
                     " Error in applying transport property mapping for '" + sourceType
@@ -112,6 +114,7 @@ public class InputEventHandler {
                 }
             }
             inputEventHandlerCallback.sendEvents(events, transportSyncProperties);
+            eventCount += events.length;
         } catch (RuntimeException e) {
             LOG.error(ExceptionUtil.getMessageWithContext(e, siddhiAppContext) +
                     " Error in applying transport property mapping for '" + sourceType
@@ -120,5 +123,9 @@ public class InputEventHandler {
             trpProperties.remove();
             trpSyncProperties.remove();
         }
+    }
+
+    long getEventCount() {
+        return eventCount;
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/SourceMapper.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/SourceMapper.java
@@ -228,6 +228,10 @@ public abstract class SourceMapper implements SourceEventListener {
         return streamDefinition;
     }
 
+    public long getEventCount() {
+        return this.inputEventHandler.getEventCount();
+    }
+
     /**
      * Method to map the incoming event and as pass that via inputEventHandler to process further.
      *


### PR DESCRIPTION
## Purpose
> Add a counter to count and get total inputs got into the siddhi app after mapping.

## Usage
> To count the dropped events count while mapping.
`((SourceMapper)sourceEventListener).getEventCount()`

## Approach
> Introduce a new variable called `eventCount` in the `InputEventHandler` class.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

