### PR TITLE
[Error Handler] Maintain events as byte[] in ErrorEntry

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -237,6 +237,10 @@
         <Bug pattern="EI_EXPOSE_REP"/>
     </Match>
     <Match>
+        <Class name="io.siddhi.core.util.error.handler.model.ErrorEntry"/>
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </Match>
+    <Match>
         <Class name="io.siddhi.core.util.error.handler.model.PublishableErrorEntry"/>
         <Bug pattern="EI_EXPOSE_REP"/>
     </Match>

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ErrorEntry.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ErrorEntry.java
@@ -32,22 +32,22 @@ public class ErrorEntry {
     private String streamName;
     private byte[] eventAsBytes;
     private String cause;
-    private byte[] stackTraceAsBytes;
+    private String stackTrace;
     private byte[] originalPayloadAsBytes;
     private ErrorOccurrence errorOccurrence;
     private ErroneousEventType eventType;
     private ErrorType errorType;
 
     public ErrorEntry(int id, long timestamp, String siddhiAppName, String streamName, byte[] eventAsBytes,
-                      String cause, byte[] stackTraceAsBytes, byte[] originalPayloadAsBytes,
-                      ErrorOccurrence errorOccurrence, ErroneousEventType eventType, ErrorType errorType) {
+                      String cause, String stackTrace, byte[] originalPayloadAsBytes, ErrorOccurrence errorOccurrence,
+                      ErroneousEventType eventType, ErrorType errorType) {
         this.id = id;
         this.timestamp = timestamp;
         this.siddhiAppName = siddhiAppName;
         this.streamName = streamName;
         this.eventAsBytes = eventAsBytes;
         this.cause = cause;
-        this.stackTraceAsBytes = stackTraceAsBytes;
+        this.stackTrace = stackTrace;
         this.originalPayloadAsBytes = originalPayloadAsBytes;
         this.errorOccurrence = errorOccurrence;
         this.eventType = eventType;
@@ -78,8 +78,8 @@ public class ErrorEntry {
         return cause;
     }
 
-    public byte[] getStackTraceAsBytes() {
-        return stackTraceAsBytes;
+    public String getStackTrace() {
+        return stackTrace;
     }
 
     public byte[] getOriginalPayloadAsBytes() {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ErrorEntry.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ErrorEntry.java
@@ -33,13 +33,13 @@ public class ErrorEntry {
     private byte[] eventAsBytes;
     private String cause;
     private String stackTrace;
-    private byte[] originalPayloadAsBytes;
+    private String originalPayload;
     private ErrorOccurrence errorOccurrence;
     private ErroneousEventType eventType;
     private ErrorType errorType;
 
     public ErrorEntry(int id, long timestamp, String siddhiAppName, String streamName, byte[] eventAsBytes,
-                      String cause, String stackTrace, byte[] originalPayloadAsBytes, ErrorOccurrence errorOccurrence,
+                      String cause, String stackTrace, String originalPayload, ErrorOccurrence errorOccurrence,
                       ErroneousEventType eventType, ErrorType errorType) {
         this.id = id;
         this.timestamp = timestamp;
@@ -48,7 +48,7 @@ public class ErrorEntry {
         this.eventAsBytes = eventAsBytes;
         this.cause = cause;
         this.stackTrace = stackTrace;
-        this.originalPayloadAsBytes = originalPayloadAsBytes;
+        this.originalPayload = originalPayload;
         this.errorOccurrence = errorOccurrence;
         this.eventType = eventType;
         this.errorType = errorType;
@@ -82,8 +82,8 @@ public class ErrorEntry {
         return stackTrace;
     }
 
-    public byte[] getOriginalPayloadAsBytes() {
-        return originalPayloadAsBytes;
+    public String getOriginalPayload() {
+        return originalPayload;
     }
 
     public ErrorOccurrence getErrorOccurrence() {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ErrorEntry.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ErrorEntry.java
@@ -24,15 +24,13 @@ import io.siddhi.core.util.error.handler.util.ErrorType;
 
 /**
  * Represents an entry which represents an error, in the {@link io.siddhi.core.util.error.handler.store.ErrorStore}.
- *
- * @param <T> Type of the contained event.
  */
-public class ErrorEntry<T> {
+public class ErrorEntry {
     private int id;
     private long timestamp;
     private String siddhiAppName;
     private String streamName;
-    private T event;
+    private byte[] eventAsBytes;
     private String cause;
     private String stackTrace;
     private String originalPayload;
@@ -40,14 +38,14 @@ public class ErrorEntry<T> {
     private ErroneousEventType eventType;
     private ErrorType errorType;
 
-    public ErrorEntry(int id, long timestamp, String siddhiAppName, String streamName, T event, String cause,
-                      String stackTrace, String originalPayload, ErrorOccurrence errorOccurrence,
+    public ErrorEntry(int id, long timestamp, String siddhiAppName, String streamName, byte[] eventAsBytes,
+                      String cause, String stackTrace, String originalPayload, ErrorOccurrence errorOccurrence,
                       ErroneousEventType eventType, ErrorType errorType) {
         this.id = id;
         this.timestamp = timestamp;
         this.siddhiAppName = siddhiAppName;
         this.streamName = streamName;
-        this.event = event;
+        this.eventAsBytes = eventAsBytes;
         this.cause = cause;
         this.stackTrace = stackTrace;
         this.originalPayload = originalPayload;
@@ -72,8 +70,8 @@ public class ErrorEntry<T> {
         return streamName;
     }
 
-    public T getEvent() {
-        return event;
+    public byte[] getEventAsBytes() {
+        return eventAsBytes;
     }
 
     public String getCause() {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ErrorEntry.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ErrorEntry.java
@@ -32,23 +32,23 @@ public class ErrorEntry {
     private String streamName;
     private byte[] eventAsBytes;
     private String cause;
-    private String stackTrace;
-    private String originalPayload;
+    private byte[] stackTraceAsBytes;
+    private byte[] originalPayloadAsBytes;
     private ErrorOccurrence errorOccurrence;
     private ErroneousEventType eventType;
     private ErrorType errorType;
 
     public ErrorEntry(int id, long timestamp, String siddhiAppName, String streamName, byte[] eventAsBytes,
-                      String cause, String stackTrace, String originalPayload, ErrorOccurrence errorOccurrence,
-                      ErroneousEventType eventType, ErrorType errorType) {
+                      String cause, byte[] stackTraceAsBytes, byte[] originalPayloadAsBytes,
+                      ErrorOccurrence errorOccurrence, ErroneousEventType eventType, ErrorType errorType) {
         this.id = id;
         this.timestamp = timestamp;
         this.siddhiAppName = siddhiAppName;
         this.streamName = streamName;
         this.eventAsBytes = eventAsBytes;
         this.cause = cause;
-        this.stackTrace = stackTrace;
-        this.originalPayload = originalPayload;
+        this.stackTraceAsBytes = stackTraceAsBytes;
+        this.originalPayloadAsBytes = originalPayloadAsBytes;
         this.errorOccurrence = errorOccurrence;
         this.eventType = eventType;
         this.errorType = errorType;
@@ -78,12 +78,12 @@ public class ErrorEntry {
         return cause;
     }
 
-    public String getStackTrace() {
-        return stackTrace;
+    public byte[] getStackTraceAsBytes() {
+        return stackTraceAsBytes;
     }
 
-    public String getOriginalPayload() {
-        return originalPayload;
+    public byte[] getOriginalPayloadAsBytes() {
+        return originalPayloadAsBytes;
     }
 
     public ErrorOccurrence getErrorOccurrence() {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
@@ -170,12 +170,9 @@ public abstract class ErrorStore {
     protected ErrorEntry constructErrorEntry(int id, long timestamp, String siddhiAppName, String streamName,
                                              byte[] eventAsBytes, String cause, byte[] stackTraceAsBytes,
                                              byte[] originalPayloadAsBytes, ErrorOccurrence errorOccurrence,
-                                             ErroneousEventType erroneousEventType, ErrorType errorType)
-            throws IOException, ClassNotFoundException {
-        String originalPayloadString =
-                ErrorHandlerUtils.getOriginalPayloadString(ErrorHandlerUtils.getAsObject(originalPayloadAsBytes));
+                                             ErroneousEventType erroneousEventType, ErrorType errorType) {
         return new ErrorEntry(id, timestamp, siddhiAppName, streamName, eventAsBytes, cause,
-                (String) ErrorHandlerUtils.getAsObject(stackTraceAsBytes), originalPayloadString, errorOccurrence,
+                stackTraceAsBytes, originalPayloadAsBytes, errorOccurrence,
                 erroneousEventType, errorType);
     }
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
@@ -31,7 +31,7 @@ import io.siddhi.core.util.error.handler.model.ErrorEntry;
 import io.siddhi.core.util.error.handler.model.PublishableErrorEntry;
 import io.siddhi.core.util.error.handler.util.ErroneousEventType;
 import io.siddhi.core.util.error.handler.util.ErrorOccurrence;
-import io.siddhi.core.util.error.handler.util.ErrorStoreUtils;
+import io.siddhi.core.util.error.handler.util.ErrorHandlerUtils;
 import io.siddhi.core.util.error.handler.util.ErrorType;
 import org.apache.log4j.Logger;
 
@@ -148,10 +148,10 @@ public abstract class ErrorStore {
         try {
             Object originalPayload = erroneousEvent.getOriginalPayload();
             byte[] eventAsBytes = (event != null && eventType == ErroneousEventType.PAYLOAD_STRING) ?
-                    ErrorStoreUtils.getAsBytes(event.toString()) : ErrorStoreUtils.getAsBytes(event);
-            byte[] stackTraceAsBytes = (throwable != null) ? ErrorStoreUtils.getThrowableStackTraceAsBytes(throwable) :
-                    ErrorStoreUtils.getAsBytes(null);
-            byte[] originalPayloadAsBytes = ErrorStoreUtils.getAsBytes(originalPayload);
+                    ErrorHandlerUtils.getAsBytes(event.toString()) : ErrorHandlerUtils.getAsBytes(event);
+            byte[] stackTraceAsBytes = (throwable != null) ?
+                    ErrorHandlerUtils.getThrowableStackTraceAsBytes(throwable) : ErrorHandlerUtils.getAsBytes(null);
+            byte[] originalPayloadAsBytes = ErrorHandlerUtils.getAsBytes(originalPayload);
 
             produce(timestamp, siddhiAppName, streamName, eventAsBytes, cause, stackTraceAsBytes,
                     originalPayloadAsBytes, errorOccurrence.toString(), eventType.toString(), errorType.toString());
@@ -173,10 +173,9 @@ public abstract class ErrorStore {
                                              ErroneousEventType erroneousEventType, ErrorType errorType)
             throws IOException, ClassNotFoundException {
         String originalPayloadString =
-                ErrorStoreUtils.getOriginalPayloadString(ErrorStoreUtils.getAsObject(originalPayloadAsBytes));
-        Object eventObject = ErrorStoreUtils.getAsObject(eventAsBytes);
-        return new ErrorEntry<>(id, timestamp, siddhiAppName, streamName, eventObject, cause,
-                (String) ErrorStoreUtils.getAsObject(stackTraceAsBytes), originalPayloadString, errorOccurrence,
+                ErrorHandlerUtils.getOriginalPayloadString(ErrorHandlerUtils.getAsObject(originalPayloadAsBytes));
+        return new ErrorEntry(id, timestamp, siddhiAppName, streamName, eventAsBytes, cause,
+                (String) ErrorHandlerUtils.getAsObject(stackTraceAsBytes), originalPayloadString, errorOccurrence,
                 erroneousEventType, errorType);
     }
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
@@ -170,11 +170,15 @@ public abstract class ErrorStore {
     protected ErrorEntry constructErrorEntry(int id, long timestamp, String siddhiAppName, String streamName,
                                              byte[] eventAsBytes, String cause, byte[] stackTraceAsBytes,
                                              byte[] originalPayloadAsBytes, ErrorOccurrence errorOccurrence,
-                                             ErroneousEventType erroneousEventType, ErrorType errorType) {
-        return new ErrorEntry(id, timestamp, siddhiAppName, streamName, eventAsBytes, cause,
-                stackTraceAsBytes, originalPayloadAsBytes, errorOccurrence,
-                erroneousEventType, errorType);
+                                             ErroneousEventType erroneousEventType, ErrorType errorType)
+            throws IOException, ClassNotFoundException {
+        String stackTrace = stackTraceAsBytes != null ?
+                (String) ErrorHandlerUtils.getAsObject(stackTraceAsBytes) : null;
+        return new ErrorEntry(id, timestamp, siddhiAppName, streamName, eventAsBytes, cause, stackTrace,
+                originalPayloadAsBytes, errorOccurrence, erroneousEventType, errorType);
     }
+
+    public abstract ErrorEntry loadErrorEntry(int id);
 
     public abstract void discardErroneousEvent(int id);
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
@@ -96,6 +96,14 @@ public abstract class ErrorStore {
 
     public abstract void setProperties(Map properties);
 
+    public void setBufferSize(int bufferSize) {
+        this.bufferSize = bufferSize;
+    }
+
+    public void setDropWhenBufferFull(boolean dropWhenBufferFull) {
+        this.dropWhenBufferFull = dropWhenBufferFull;
+    }
+
     public void saveBeforeSourceMappingError(String siddhiAppName, List<ErroneousEvent> erroneousEvents,
                                              String streamName) {
         for (ErroneousEvent erroneousEvent : erroneousEvents) {
@@ -167,6 +175,8 @@ public abstract class ErrorStore {
 
     public abstract List<ErrorEntry> loadErrorEntries(String siddhiAppName, Map<String, String> queryParams);
 
+    public abstract ErrorEntry loadErrorEntry(int id);
+
     protected ErrorEntry constructErrorEntry(int id, long timestamp, String siddhiAppName, String streamName,
                                              byte[] eventAsBytes, String cause, byte[] stackTraceAsBytes,
                                              byte[] originalPayloadAsBytes, ErrorOccurrence errorOccurrence,
@@ -178,17 +188,13 @@ public abstract class ErrorStore {
                 originalPayloadAsBytes, errorOccurrence, erroneousEventType, errorType);
     }
 
-    public abstract ErrorEntry loadErrorEntry(int id);
+    public abstract void discardErrorEntry(int id);
 
-    public abstract void discardErroneousEvent(int id);
+    public abstract void discardErrorEntries(String siddhiAppName);
 
-    public abstract Map getStatus();
+    public abstract int getTotalErrorEntriesCount();
 
-    public void setBufferSize(int bufferSize) {
-        this.bufferSize = bufferSize;
-    }
+    public abstract int getErrorEntriesCount(String siddhiAppName);
 
-    public void setDropWhenBufferFull(boolean dropWhenBufferFull) {
-        this.dropWhenBufferFull = dropWhenBufferFull;
-    }
+    public abstract void purge();
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
@@ -30,8 +30,8 @@ import io.siddhi.core.util.error.handler.model.ErroneousEvent;
 import io.siddhi.core.util.error.handler.model.ErrorEntry;
 import io.siddhi.core.util.error.handler.model.PublishableErrorEntry;
 import io.siddhi.core.util.error.handler.util.ErroneousEventType;
-import io.siddhi.core.util.error.handler.util.ErrorOccurrence;
 import io.siddhi.core.util.error.handler.util.ErrorHandlerUtils;
+import io.siddhi.core.util.error.handler.util.ErrorOccurrence;
 import io.siddhi.core.util.error.handler.util.ErrorType;
 import org.apache.log4j.Logger;
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
@@ -182,10 +182,13 @@ public abstract class ErrorStore {
                                              byte[] originalPayloadAsBytes, ErrorOccurrence errorOccurrence,
                                              ErroneousEventType erroneousEventType, ErrorType errorType)
             throws IOException, ClassNotFoundException {
-        String stackTrace = stackTraceAsBytes != null ?
-                (String) ErrorHandlerUtils.getAsObject(stackTraceAsBytes) : null;
+        String stackTrace = stackTraceAsBytes != null ? (String) ErrorHandlerUtils.getAsObject(stackTraceAsBytes) :
+                null;
+        String originalPayloadString = originalPayloadAsBytes != null ?
+                ErrorHandlerUtils.getOriginalPayloadString(ErrorHandlerUtils.getAsObject(originalPayloadAsBytes)) :
+                null;
         return new ErrorEntry(id, timestamp, siddhiAppName, streamName, eventAsBytes, cause, stackTrace,
-                originalPayloadAsBytes, errorOccurrence, erroneousEventType, errorType);
+                originalPayloadString, errorOccurrence, erroneousEventType, errorType);
     }
 
     public abstract void discardErrorEntry(int id);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
@@ -196,5 +196,5 @@ public abstract class ErrorStore {
 
     public abstract int getErrorEntriesCount(String siddhiAppName);
 
-    public abstract void purge();
+    public abstract void purge(Map retentionPolicyParams);
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/util/ErrorHandlerUtils.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/util/ErrorHandlerUtils.java
@@ -27,11 +27,11 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 /**
- * Contains utility methods for the error store.
+ * Contains utility methods for the error handler.
  */
-public class ErrorStoreUtils {
+public class ErrorHandlerUtils {
 
-    private ErrorStoreUtils() {}
+    private ErrorHandlerUtils() {}
 
     public static byte[] getAsBytes(Object event) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
## Purpose
#### Maintain events as `byte[]` in `ErrorEntry`
> We use the [`ErrorEntry`](https://github.com/siddhi-io/siddhi/pull/1662/files#diff-f4fd3d1bde0e22f266cf9ce896a580a5R30) class to describe an error entry from the error store. 
- The event collected due to a error (eg: `Event`, `ComplexEvent` & etc) is [stored as a BLOB in the error store](https://github.com/siddhi-io/siddhi/pull/1662/files#diff-5641ac941cccafc2e4da4f6a9c813b00R164).
- When the error handler API's [`GET /error-handler/erroneous-events`](https://github.com/wso2/carbon-analytics/pull/1868/files#diff-86f8ec3bdca61bff7ca6d17e58b9a4cfR73) is invoked, the blob is [converted back to the appropriate event object](https://github.com/siddhi-io/siddhi/pull/1662/files#diff-5641ac941cccafc2e4da4f6a9c813b00R177), loaded as an `ErrorEntry` and will be sent as a JSON response.
- Since it's a JSON response, the `ErrorEntry` that contains the event is mapped to a JSON and sent.
In case if this JSON mapping fails, we can not replay the event properly.

This PR makes `ErrorEntry` to contain the event in a `byte[]`, rather than in a variable of the appropriate event type. The `byte[]` will be converted to the appropriate event type only during a replay, with the [`ErroneousEventType`](https://github.com/siddhi-io/siddhi/pull/1662/files#diff-34f2cf865b2eb036ca0e491461ee58eeR25) we already have.

#### Add methods to interact with records in the Error Store
> Methods were introduced to perform the following actions with the error store:
> - Discard error entries with the given Siddhi app name
> - Get total error entries count
> - Get the count of error entries that belong the given Siddhi app
> - Purge

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> - https://github.com/siddhi-io/siddhi/pull/1662
> - https://github.com/wso2/carbon-analytics/pull/1868
