### PR TITLE
Handle database errors for replaying

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/exception/DatabaseConstraintViolationException.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/exception/DatabaseConstraintViolationException.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.exception;
+
+/**
+ * Represents an unchecked exception which may be thrown during runtime, from which we may not expect the Siddhi runtime
+ * to reasonable recover.
+ */
+public class DatabaseConstraintViolationException extends SiddhiAppRuntimeException {
+
+    private static final long serialVersionUID = 6844270338346626310L;
+
+    public DatabaseConstraintViolationException(String message) {
+        super(message);
+    }
+
+    public DatabaseConstraintViolationException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
+    public DatabaseConstraintViolationException(Throwable throwable) {
+        super(throwable);
+    }
+
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/exception/DatabaseRuntimeException.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/exception/DatabaseRuntimeException.java
@@ -21,19 +21,19 @@ package io.siddhi.core.exception;
  * Represents an unchecked exception which may be thrown during runtime, from which we may not expect the Siddhi runtime
  * to reasonable recover.
  */
-public class DatabaseConstraintViolationException extends SiddhiAppRuntimeException {
+public class DatabaseRuntimeException extends SiddhiAppRuntimeException {
 
     private static final long serialVersionUID = 6844270338346626310L;
 
-    public DatabaseConstraintViolationException(String message) {
+    public DatabaseRuntimeException(String message) {
         super(message);
     }
 
-    public DatabaseConstraintViolationException(String message, Throwable throwable) {
+    public DatabaseRuntimeException(String message, Throwable throwable) {
         super(message, throwable);
     }
 
-    public DatabaseConstraintViolationException(Throwable throwable) {
+    public DatabaseRuntimeException(Throwable throwable) {
         super(throwable);
     }
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/Sink.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/output/sink/Sink.java
@@ -93,6 +93,11 @@ public abstract class Sink<S extends State> implements SinkListener {
         this.onErrorAction = OnErrorAction.valueOf(transportOptionHolder
                 .getOrCreateOption(SiddhiConstants.ANNOTATION_ELEMENT_ON_ERROR, "LOG")
                 .getValue().toUpperCase());
+        if (this.onErrorAction == OnErrorAction.STORE && siddhiAppContext.getSiddhiContext().getErrorStore() == null) {
+            LOG.error("On error action is 'STORE' for sink connected to stream " + streamDefinition.getId()
+                    + " in Siddhi App " + siddhiAppContext.getName() + " but error store is not configured in Siddhi " +
+                    "Manager");
+        }
         if (siddhiAppContext.getStatisticsManager() != null) {
             this.throughputTracker = QueryParserHelper.createThroughputTracker(siddhiAppContext,
                     streamDefinition.getId(),

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/table/Table.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/table/Table.java
@@ -218,13 +218,14 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
         JsonObject payloadJson = new JsonObject();
         payloadJson.addProperty("isEditable", !isObjectColumnPresent);
         JsonArray attributes = new JsonArray();
+        JsonArray attributeTypes = new JsonArray();
         JsonArray records = new JsonArray();
         for (Attribute attribute : tableDefinition.getAttributeList()) {
-            JsonObject attributeJson = new JsonObject();
-            attributeJson.addProperty(attribute.getName(), String.valueOf(attribute.getType()));
-            attributes.add(attributeJson);
+            attributes.add(attribute.getName());
+            attributeTypes.add(String.valueOf(attribute.getType()));
         }
         payloadJson.add("attributes", attributes);
+        payloadJson.add("attributeTypes", attributeTypes);
         while (eventChunk.hasNext()) {
             StreamEvent streamEvent = eventChunk.next();
             JsonArray record = new JsonArray();
@@ -241,12 +242,14 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
         JsonObject payloadJson = new JsonObject();
         payloadJson.addProperty("isEditable", !isObjectColumnPresent);
         JsonArray attributes = new JsonArray();
+        JsonArray attributeTypes = new JsonArray();
         JsonArray records = new JsonArray();
         for (Attribute attribute : tableDefinition.getAttributeList()) {
-            JsonObject attributeJson = new JsonObject();
-            attributeJson.addProperty(attribute.getName(), String.valueOf(attribute.getType()));
-            attributes.add(attributeJson);
+            attributes.add(attribute.getName());
+            attributeTypes.add(String.valueOf(attribute.getType()));
         }
+        payloadJson.add("attributes", attributes);
+        payloadJson.add("attributeTypes", attributeTypes);
         while (eventChunk.hasNext()) {
             StateEvent stateEvent = eventChunk.next();
             for (StreamEvent streamEvent : stateEvent.getStreamEvents()) {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/table/Table.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/table/Table.java
@@ -108,39 +108,38 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
             this.onErrorAction = OnErrorAction.valueOf(onErrorElement.getValue());
         }
         if (this.onErrorAction == OnErrorAction.STORE && siddhiAppContext.getSiddhiContext().getErrorStore() == null) {
-            // TODO: 2020-10-02 add in streams
             LOG.error("On error action is 'STORE' for table " + tableDefinition.getId() + " in Siddhi App "
                     + siddhiAppContext.getName() + " but error store is not configured in Siddhi Manager");
         }
         this.isObjectColumnPresent = isObjectColumnPresent(tableDefinition);
         if (siddhiAppContext.getStatisticsManager() != null) {
             latencyTrackerFind = QueryParserHelper.createLatencyTracker(siddhiAppContext, tableDefinition.getId(),
-                SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_FIND);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_FIND);
             latencyTrackerInsert = QueryParserHelper.createLatencyTracker(siddhiAppContext, tableDefinition.getId(),
-                SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_INSERT);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_INSERT);
             latencyTrackerUpdate = QueryParserHelper.createLatencyTracker(siddhiAppContext, tableDefinition.getId(),
-                SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_UPDATE);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_UPDATE);
             latencyTrackerDelete = QueryParserHelper.createLatencyTracker(siddhiAppContext, tableDefinition.getId(),
-                SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_DELETE);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_DELETE);
             latencyTrackerUpdateOrInsert = QueryParserHelper.createLatencyTracker(siddhiAppContext,
-                tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES,
-                SiddhiConstants.METRIC_TYPE_UPDATE_OR_INSERT);
+                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES,
+                    SiddhiConstants.METRIC_TYPE_UPDATE_OR_INSERT);
             latencyTrackerContains = QueryParserHelper.createLatencyTracker(siddhiAppContext, tableDefinition.getId(),
-                SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_CONTAINS);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_CONTAINS);
 
             throughputTrackerFind = QueryParserHelper.createThroughputTracker(siddhiAppContext, tableDefinition.getId(),
-                SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_FIND);
+                    SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_FIND);
             throughputTrackerInsert = QueryParserHelper.createThroughputTracker(siddhiAppContext,
-                tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_INSERT);
+                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_INSERT);
             throughputTrackerUpdate = QueryParserHelper.createThroughputTracker(siddhiAppContext,
-                tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_UPDATE);
+                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_UPDATE);
             throughputTrackerDelete = QueryParserHelper.createThroughputTracker(siddhiAppContext,
-                tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_DELETE);
+                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_DELETE);
             throughputTrackerUpdateOrInsert = QueryParserHelper.createThroughputTracker(siddhiAppContext,
-                tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES,
-                SiddhiConstants.METRIC_TYPE_UPDATE_OR_INSERT);
+                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES,
+                    SiddhiConstants.METRIC_TYPE_UPDATE_OR_INSERT);
             throughputTrackerContains = QueryParserHelper.createThroughputTracker(siddhiAppContext,
-                tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_CONTAINS);
+                    tableDefinition.getId(), SiddhiConstants.METRIC_INFIX_TABLES, SiddhiConstants.METRIC_TYPE_CONTAINS);
 
         }
         init(tableDefinition, storeEventPool, storeEventCloner, configReader, siddhiAppContext, recordTableHandler);
@@ -155,12 +154,8 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
     }
 
     private boolean isObjectColumnPresent(TableDefinition tableDefinition) {
-        for (Attribute attribute: tableDefinition.getAttributeList()) {
-            if (attribute.getType() == Attribute.Type.OBJECT) {
-                return true;
-            }
-        }
-        return false;
+        return tableDefinition.getAttributeList()
+                .stream().anyMatch(attribute -> attribute.getType() == Attribute.Type.OBJECT);
     }
 
     protected void onAddError(ComplexEventChunk<StreamEvent> addingEventChunk, Exception e) {
@@ -221,13 +216,13 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
 
     public void addEvents(ComplexEventChunk<StreamEvent> addingEventChunk, int noOfEvents) {
         if (latencyTrackerInsert != null &&
-            Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
             latencyTrackerInsert.markIn();
         }
         addingEventChunk.reset();
         add(addingEventChunk);
         if (throughputTrackerInsert != null &&
-            Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
             throughputTrackerInsert.eventsIn(noOfEvents);
         }
     }
@@ -238,35 +233,35 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
         if (isConnected.get()) {
             try {
                 if (latencyTrackerFind != null &&
-                    Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                        Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
                     latencyTrackerFind.markIn();
                 }
                 StreamEvent results = find(compiledCondition, matchingEvent);
                 if (throughputTrackerFind != null &&
-                    Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                        Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
                     throughputTrackerFind.eventIn();
                 }
                 return results;
             } catch (ConnectionUnavailableException e) {
                 isConnected.set(false);
                 LOG.error(ExceptionUtil.getMessageWithContext(e, siddhiAppContext) +
-                    " Connection unavailable at Table '" + tableDefinition.getId() +
-                    "', will retry connection immediately.", e);
+                        " Connection unavailable at Table '" + tableDefinition.getId() +
+                        "', will retry connection immediately.", e);
                 connectWithRetry();
                 return find(matchingEvent, compiledCondition);
             } finally {
                 if (latencyTrackerFind != null &&
-                    Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                        Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
                     latencyTrackerFind.markOut();
                 }
             }
         } else if (isTryingToConnect.get()) {
             LOG.warn("Error on '" + siddhiAppContext.getName() + "' while performing find for events '" +
-                matchingEvent + "', operation busy waiting at Table '" + tableDefinition.getId() +
-                "' as its trying to reconnect!");
+                    matchingEvent + "', operation busy waiting at Table '" + tableDefinition.getId() +
+                    "' as its trying to reconnect!");
             waitWhileConnect();
             LOG.info("SiddhiApp '" + siddhiAppContext.getName() + "' table '" + tableDefinition.getId() +
-                "' has become available for find operation for events '" + matchingEvent + "'");
+                    "' has become available for find operation for events '" + matchingEvent + "'");
             return find(matchingEvent, compiledCondition);
         } else {
             connectWithRetry();
@@ -275,7 +270,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
     }
 
     protected abstract StreamEvent find(CompiledCondition compiledCondition, StateEvent matchingEvent)
-        throws ConnectionUnavailableException;
+            throws ConnectionUnavailableException;
 
     protected void onDeleteError(ComplexEventChunk<StateEvent> deletingEventChunk, CompiledCondition compiledCondition,
                                  Exception e) {
@@ -329,8 +324,6 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(e);
                 }
-            } else {
-                throw (DatabaseRuntimeException) e;
             }
         }
     }
@@ -338,18 +331,18 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
     public void deleteEvents(ComplexEventChunk<StateEvent> deletingEventChunk, CompiledCondition compiledCondition,
                              int noOfEvents) {
         if (latencyTrackerDelete != null &&
-            Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
             latencyTrackerDelete.markIn();
         }
         delete(deletingEventChunk, compiledCondition);
         if (throughputTrackerDelete != null &&
-            Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
             throughputTrackerDelete.eventsIn(noOfEvents);
         }
     }
 
     public abstract void delete(ComplexEventChunk<StateEvent> deletingEventChunk,
-                                CompiledCondition compiledCondition);
+                                    CompiledCondition compiledCondition);
 
     protected void onUpdateError(ComplexEventChunk<StateEvent> updatingEventChunk, CompiledCondition compiledCondition,
                                  CompiledUpdateSet compiledUpdateSet, Exception e) {
@@ -408,16 +401,14 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(e);
                 }
-            } else {
-                throw (DatabaseRuntimeException) e;
             }
         }
     }
 
 
     public void updateEvents(ComplexEventChunk<StateEvent> updatingEventChunk,
-                             CompiledCondition compiledCondition,
-                             CompiledUpdateSet compiledUpdateSet, int noOfEvents) {
+                                CompiledCondition compiledCondition,
+                                CompiledUpdateSet compiledUpdateSet, int noOfEvents) {
         if (latencyTrackerUpdate != null &&
             Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
             latencyTrackerUpdate.markIn();
@@ -434,9 +425,9 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                                 CompiledUpdateSet compiledUpdateSet);
 
     protected void onUpdateOrAddError(ComplexEventChunk<StateEvent> updateOrAddingEventChunk,
-                                      CompiledCondition compiledCondition, CompiledUpdateSet compiledUpdateSet,
-                                      AddingStreamEventExtractor addingStreamEventExtractor,
-                                      Exception e) {
+                                        CompiledCondition compiledCondition, CompiledUpdateSet compiledUpdateSet,
+                                        AddingStreamEventExtractor addingStreamEventExtractor,
+                                        Exception e) {
         OnErrorAction errorAction = onErrorAction;
         if (e instanceof ConnectionUnavailableException) {
             isConnected.set(false);
@@ -494,8 +485,6 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(e);
                 }
-            } else {
-                throw (DatabaseRuntimeException) e;
             }
         }
     }
@@ -505,55 +494,55 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                                   CompiledUpdateSet compiledUpdateSet,
                                   AddingStreamEventExtractor addingStreamEventExtractor, int noOfEvents) {
         if (latencyTrackerUpdateOrInsert != null &&
-            Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
             latencyTrackerUpdateOrInsert.markIn();
         }
         updateOrAdd(updateOrAddingEventChunk, compiledCondition, compiledUpdateSet,
-            addingStreamEventExtractor);
+                addingStreamEventExtractor);
         if (throughputTrackerUpdateOrInsert != null &&
-            Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
             throughputTrackerUpdateOrInsert.eventsIn(noOfEvents);
         }
     }
 
     public abstract void updateOrAdd(ComplexEventChunk<StateEvent> updateOrAddingEventChunk,
-                                     CompiledCondition compiledCondition,
-                                     CompiledUpdateSet compiledUpdateSet,
-                                     AddingStreamEventExtractor addingStreamEventExtractor);
+                                        CompiledCondition compiledCondition,
+                                        CompiledUpdateSet compiledUpdateSet,
+                                        AddingStreamEventExtractor addingStreamEventExtractor);
 
     public boolean containsEvent(StateEvent matchingEvent, CompiledCondition compiledCondition) {
         if (isConnected.get()) {
             try {
                 if (latencyTrackerContains != null &&
-                    Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                        Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
                     latencyTrackerContains.markIn();
                 }
                 boolean results = contains(matchingEvent, compiledCondition);
                 if (throughputTrackerContains != null &&
-                    Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                        Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
                     throughputTrackerContains.eventIn();
                 }
                 return results;
             } catch (ConnectionUnavailableException e) {
                 isConnected.set(false);
                 LOG.error(ExceptionUtil.getMessageWithContext(e, siddhiAppContext) +
-                    " Connection unavailable at Table '" + tableDefinition.getId() +
-                    "', will retry connection immediately.", e);
+                        " Connection unavailable at Table '" + tableDefinition.getId() +
+                        "', will retry connection immediately.", e);
                 connectWithRetry();
                 return containsEvent(matchingEvent, compiledCondition);
             } finally {
                 if (latencyTrackerContains != null &&
-                    Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+                        Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
                     latencyTrackerContains.markOut();
                 }
             }
         } else if (isTryingToConnect.get()) {
             LOG.warn("Error on '" + siddhiAppContext.getName() + "' while performing contains check for event '" +
-                matchingEvent + "', operation busy waiting at Table '" + tableDefinition.getId() +
-                "' as its trying to reconnect!");
+                    matchingEvent + "', operation busy waiting at Table '" + tableDefinition.getId() +
+                    "' as its trying to reconnect!");
             waitWhileConnect();
             LOG.info("SiddhiApp '" + siddhiAppContext.getName() + "' table '" + tableDefinition.getId() +
-                "' has become available for contains check operation for matching event '" + matchingEvent + "'");
+                    "' has become available for contains check operation for matching event '" + matchingEvent + "'");
             return containsEvent(matchingEvent, compiledCondition);
         } else {
             connectWithRetry();
@@ -562,7 +551,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
     }
 
     protected abstract boolean contains(StateEvent matchingEvent, CompiledCondition compiledCondition)
-        throws ConnectionUnavailableException;
+            throws ConnectionUnavailableException;
 
     public void connectWithRetry() {
         if (!isConnected.get()) {
@@ -577,10 +566,10 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                 backoffRetryCounter.reset();
             } catch (ConnectionUnavailableException e) {
                 LOG.error(StringUtil.removeCRLFCharacters(ExceptionUtil.getMessageWithContext(e,
-                    siddhiAppContext)) + " Error while connecting to Table '" +
-                    StringUtil.removeCRLFCharacters(tableDefinition.getId())
-                    + "', will retry in '" + StringUtil.removeCRLFCharacters(
-                    backoffRetryCounter.getTimeInterval()) + "'.", e);
+                        siddhiAppContext)) + " Error while connecting to Table '" +
+                        StringUtil.removeCRLFCharacters(tableDefinition.getId())
+                        + "', will retry in '" + StringUtil.removeCRLFCharacters(
+                        backoffRetryCounter.getTimeInterval()) + "'.", e);
                 scheduledExecutorService.schedule(new Runnable() {
                     @Override
                     public void run() {
@@ -590,8 +579,8 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                 backoffRetryCounter.increment();
             } catch (RuntimeException e) {
                 LOG.error(StringUtil.removeCRLFCharacters(ExceptionUtil.getMessageWithContext(e,
-                    siddhiAppContext)) + " . Error while connecting to Table '" +
-                    StringUtil.removeCRLFCharacters(tableDefinition.getId()) + "'.", e);
+                        siddhiAppContext)) + " . Error while connecting to Table '" +
+                        StringUtil.removeCRLFCharacters(tableDefinition.getId()) + "'.", e);
                 throw e;
             }
         }
@@ -622,7 +611,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
             }
         } catch (InterruptedException e) {
             throw new RuntimeException("Error on SiddhiApp '" + siddhiAppContext.getName() + "', interrupted while " +
-                "busy wait on connection retrying condition " + e.getMessage(), e);
+                    "busy wait on connection retrying condition " + e.getMessage(), e);
         }
     }
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/table/Table.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/table/Table.java
@@ -213,7 +213,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
         record.setEditable(!isObjectColumnPresent);
         ErroneousEvent erroneousEvent = new ErroneousEvent(record, e, e.getMessage());
         erroneousEvent.setOriginalPayload(ErrorHandlerUtils.constructAddErrorRecordString(addingEventChunk,
-                isFromConnectionUnavailableException, tableDefinition));
+                isFromConnectionUnavailableException, tableDefinition, e));
         ErrorStoreHelper.storeErroneousEvent(siddhiAppContext.getSiddhiContext().getErrorStore(),
                 ErrorOccurrence.STORE_ON_TABLE_ADD, siddhiAppContext.getName(), erroneousEvent,
                 tableDefinition.getId());
@@ -287,7 +287,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                 ErroneousEvent erroneousEvent = new ErroneousEvent(
                         new ReplayableTableRecord(deletingEventChunk, compiledCondition), e, e.getMessage());
                 erroneousEvent.setOriginalPayload(ErrorHandlerUtils.constructErrorRecordString(deletingEventChunk,
-                        isObjectColumnPresent, tableDefinition));
+                        isObjectColumnPresent, tableDefinition, e));
                 ErrorStoreHelper.storeErroneousEvent(siddhiAppContext.getSiddhiContext().getErrorStore(),
                         ErrorOccurrence.STORE_ON_TABLE_DELETE, siddhiAppContext.getName(), erroneousEvent,
                         tableDefinition.getId());
@@ -320,7 +320,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                 record.setFromConnectionUnavailableException(false);
                 ErroneousEvent erroneousEvent = new ErroneousEvent(record, e, e.getMessage());
                 erroneousEvent.setOriginalPayload(ErrorHandlerUtils.constructErrorRecordString(deletingEventChunk,
-                        isObjectColumnPresent, tableDefinition));
+                        isObjectColumnPresent, tableDefinition, e));
                 ErrorStoreHelper.storeErroneousEvent(siddhiAppContext.getSiddhiContext().getErrorStore(),
                         ErrorOccurrence.STORE_ON_TABLE_DELETE, siddhiAppContext.getName(), erroneousEvent,
                         tableDefinition.getId());
@@ -362,7 +362,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                         new ReplayableTableRecord(updatingEventChunk, compiledCondition, compiledUpdateSet), e,
                         e.getMessage());
                 erroneousEvent.setOriginalPayload(ErrorHandlerUtils.constructErrorRecordString(updatingEventChunk,
-                        isObjectColumnPresent, tableDefinition));
+                        isObjectColumnPresent, tableDefinition, e));
                 ErrorStoreHelper.storeErroneousEvent(siddhiAppContext.getSiddhiContext().getErrorStore(),
                         ErrorOccurrence.STORE_ON_TABLE_UPDATE, siddhiAppContext.getName(), erroneousEvent,
                         tableDefinition.getId());
@@ -398,7 +398,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                 record.setFromConnectionUnavailableException(false);
                 ErroneousEvent erroneousEvent = new ErroneousEvent(record, e, e.getMessage());
                 erroneousEvent.setOriginalPayload(ErrorHandlerUtils.constructErrorRecordString(updatingEventChunk,
-                        isObjectColumnPresent, tableDefinition));
+                        isObjectColumnPresent, tableDefinition, e));
                 ErrorStoreHelper.storeErroneousEvent(siddhiAppContext.getSiddhiContext().getErrorStore(),
                         ErrorOccurrence.STORE_ON_TABLE_UPDATE, siddhiAppContext.getName(), erroneousEvent,
                         tableDefinition.getId());
@@ -446,7 +446,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                         new ReplayableTableRecord(updateOrAddingEventChunk, compiledCondition, compiledUpdateSet,
                                 addingStreamEventExtractor), e, e.getMessage());
                 erroneousEvent.setOriginalPayload(ErrorHandlerUtils.constructErrorRecordString(updateOrAddingEventChunk,
-                        isObjectColumnPresent, tableDefinition));
+                        isObjectColumnPresent, tableDefinition, e));
                 ErrorStoreHelper.storeErroneousEvent(siddhiAppContext.getSiddhiContext().getErrorStore(),
                         ErrorOccurrence.STORE_ON_TABLE_UPDATE_OR_ADD, siddhiAppContext.getName(), erroneousEvent,
                         tableDefinition.getId());
@@ -484,7 +484,7 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
                 record.setFromConnectionUnavailableException(false);
                 ErroneousEvent erroneousEvent = new ErroneousEvent(record, e, e.getMessage());
                 erroneousEvent.setOriginalPayload(ErrorHandlerUtils.constructErrorRecordString(updateOrAddingEventChunk,
-                        isObjectColumnPresent, tableDefinition));
+                        isObjectColumnPresent, tableDefinition, e));
                 ErrorStoreHelper.storeErroneousEvent(siddhiAppContext.getSiddhiContext().getErrorStore(),
                         ErrorOccurrence.STORE_ON_TABLE_UPDATE_OR_ADD, siddhiAppContext.getName(), erroneousEvent,
                         tableDefinition.getId());

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
@@ -37,7 +37,6 @@ import io.siddhi.core.util.collection.operator.CompiledCondition;
 import io.siddhi.core.util.collection.operator.CompiledExpression;
 import io.siddhi.core.util.collection.operator.MatchingMetaInfoHolder;
 import io.siddhi.core.util.config.ConfigReader;
-import io.siddhi.core.util.error.handler.util.ErrorOccurrence;
 import io.siddhi.core.util.parser.ExpressionParser;
 import io.siddhi.core.util.transport.DynamicOptions;
 import io.siddhi.query.api.definition.TableDefinition;
@@ -110,7 +109,7 @@ public abstract class AbstractRecordTable extends Table {
                 add(records);
             }
         } catch (ConnectionUnavailableException | DatabaseConstraintViolationException e) {
-            onAddError(addingEventChunk, e, ErrorOccurrence.STORE_ON_TABLE_ADD);
+            onAddError(addingEventChunk, e);
         }
         // TODO: 2020-09-25 catch  SiddhiAppRuntimeException and validate for RDBMS constraint violation exception
         //  and handle it. Don't give replay option for these types of errors
@@ -226,8 +225,8 @@ public abstract class AbstractRecordTable extends Table {
             } else {
                 delete(deleteConditionParameterMaps, recordStoreCompiledCondition.getCompiledCondition());
             }
-        } catch (ConnectionUnavailableException e) {
-            onDeleteError(deletingEventChunk, compiledCondition, e, ErrorOccurrence.STORE_ON_TABLE_DELETE);
+        } catch (ConnectionUnavailableException | DatabaseConstraintViolationException e) {
+            onDeleteError(deletingEventChunk, compiledCondition, e);
         }
 
     }
@@ -288,9 +287,9 @@ public abstract class AbstractRecordTable extends Table {
                 update(recordStoreCompiledCondition.getCompiledCondition(), updateConditionParameterMaps,
                         recordTableCompiledUpdateSet.getUpdateSetMap(), updateSetParameterMaps);
             }
-        } catch (ConnectionUnavailableException e) {
-            onUpdateError(updatingEventChunk, compiledCondition, compiledUpdateSet, e,
-                    ErrorOccurrence.STORE_ON_TABLE_UPDATE);
+        } catch (ConnectionUnavailableException | DatabaseConstraintViolationException e) {
+            onUpdateError(updatingEventChunk, compiledCondition, compiledUpdateSet, e
+            );
         }
     }
 
@@ -351,9 +350,9 @@ public abstract class AbstractRecordTable extends Table {
                 updateOrAdd(recordStoreCompiledCondition.getCompiledCondition(), updateConditionParameterMaps,
                         recordTableCompiledUpdateSet.getUpdateSetMap(), updateSetParameterMaps, addingRecords);
             }
-        } catch (ConnectionUnavailableException e) {
+        } catch (ConnectionUnavailableException | DatabaseConstraintViolationException e) {
             onUpdateOrAddError(updateOrAddingEventChunk, compiledCondition, compiledUpdateSet,
-                    addingStreamEventExtractor, e, ErrorOccurrence.STORE_ON_TABLE_UPDATE_OR_ADD);
+                    addingStreamEventExtractor, e);
         }
     }
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
@@ -111,8 +111,6 @@ public abstract class AbstractRecordTable extends Table {
         } catch (ConnectionUnavailableException | DatabaseRuntimeException e) {
             onAddError(addingEventChunk, e);
         }
-        // TODO: 2020-09-25 catch  SiddhiAppRuntimeException and validate for RDBMS constraint violation exception
-        //  and handle it. Don't give replay option for these types of errors
     }
 
     /**

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
@@ -26,7 +26,7 @@ import io.siddhi.core.event.stream.StreamEvent;
 import io.siddhi.core.event.stream.StreamEventCloner;
 import io.siddhi.core.event.stream.StreamEventFactory;
 import io.siddhi.core.exception.ConnectionUnavailableException;
-import io.siddhi.core.exception.DatabaseConstraintViolationException;
+import io.siddhi.core.exception.DatabaseRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.VariableExpressionExecutor;
 import io.siddhi.core.query.processor.ProcessingMode;
@@ -108,7 +108,7 @@ public abstract class AbstractRecordTable extends Table {
             } else {
                 add(records);
             }
-        } catch (ConnectionUnavailableException | DatabaseConstraintViolationException e) {
+        } catch (ConnectionUnavailableException | DatabaseRuntimeException e) {
             onAddError(addingEventChunk, e);
         }
         // TODO: 2020-09-25 catch  SiddhiAppRuntimeException and validate for RDBMS constraint violation exception
@@ -225,7 +225,7 @@ public abstract class AbstractRecordTable extends Table {
             } else {
                 delete(deleteConditionParameterMaps, recordStoreCompiledCondition.getCompiledCondition());
             }
-        } catch (ConnectionUnavailableException | DatabaseConstraintViolationException e) {
+        } catch (ConnectionUnavailableException | DatabaseRuntimeException e) {
             onDeleteError(deletingEventChunk, compiledCondition, e);
         }
 
@@ -287,7 +287,7 @@ public abstract class AbstractRecordTable extends Table {
                 update(recordStoreCompiledCondition.getCompiledCondition(), updateConditionParameterMaps,
                         recordTableCompiledUpdateSet.getUpdateSetMap(), updateSetParameterMaps);
             }
-        } catch (ConnectionUnavailableException | DatabaseConstraintViolationException e) {
+        } catch (ConnectionUnavailableException | DatabaseRuntimeException e) {
             onUpdateError(updatingEventChunk, compiledCondition, compiledUpdateSet, e
             );
         }
@@ -350,7 +350,7 @@ public abstract class AbstractRecordTable extends Table {
                 updateOrAdd(recordStoreCompiledCondition.getCompiledCondition(), updateConditionParameterMaps,
                         recordTableCompiledUpdateSet.getUpdateSetMap(), updateSetParameterMaps, addingRecords);
             }
-        } catch (ConnectionUnavailableException | DatabaseConstraintViolationException e) {
+        } catch (ConnectionUnavailableException | DatabaseRuntimeException e) {
             onUpdateOrAddError(updateOrAddingEventChunk, compiledCondition, compiledUpdateSet,
                     addingStreamEventExtractor, e);
         }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
@@ -26,6 +26,7 @@ import io.siddhi.core.event.stream.StreamEvent;
 import io.siddhi.core.event.stream.StreamEventCloner;
 import io.siddhi.core.event.stream.StreamEventFactory;
 import io.siddhi.core.exception.ConnectionUnavailableException;
+import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.VariableExpressionExecutor;
 import io.siddhi.core.query.processor.ProcessingMode;
@@ -108,9 +109,13 @@ public abstract class AbstractRecordTable extends Table {
             } else {
                 add(records);
             }
-        } catch (ConnectionUnavailableException e) {
-            onAddError(addingEventChunk, e, ErrorOccurrence.STORE_ON_TABLE_ADD);
+        } catch (ConnectionUnavailableException e) { // TODO: 2020-09-25 search about handling other DB errors 
+            onAddError(addingEventChunk, e, ErrorOccurrence.STORE_ON_TABLE_ADD, true);
+        } catch (SiddhiAppRuntimeException e) { // TODO: 2020-09-28 introduce a new runtime error 
+            onAddError(addingEventChunk, e, ErrorOccurrence.STORE_ON_TABLE_ADD, false);
         }
+        // TODO: 2020-09-25 catch  SiddhiAppRuntimeException and validate for RDBMS constraint violation exception
+        //  and handle it. Don't give replay option for these types of errors
     }
 
     /**

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
@@ -109,10 +109,8 @@ public abstract class AbstractRecordTable extends Table {
             } else {
                 add(records);
             }
-        } catch (ConnectionUnavailableException e) {
-            onAddError(addingEventChunk, e, ErrorOccurrence.STORE_ON_TABLE_ADD, true);
-        } catch (DatabaseConstraintViolationException e) {
-            onAddError(addingEventChunk, e, ErrorOccurrence.STORE_ON_TABLE_ADD, false);
+        } catch (ConnectionUnavailableException | DatabaseConstraintViolationException e) {
+            onAddError(addingEventChunk, e, ErrorOccurrence.STORE_ON_TABLE_ADD);
         }
         // TODO: 2020-09-25 catch  SiddhiAppRuntimeException and validate for RDBMS constraint violation exception
         //  and handle it. Don't give replay option for these types of errors

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/table/record/AbstractRecordTable.java
@@ -26,7 +26,7 @@ import io.siddhi.core.event.stream.StreamEvent;
 import io.siddhi.core.event.stream.StreamEventCloner;
 import io.siddhi.core.event.stream.StreamEventFactory;
 import io.siddhi.core.exception.ConnectionUnavailableException;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
+import io.siddhi.core.exception.DatabaseConstraintViolationException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.VariableExpressionExecutor;
 import io.siddhi.core.query.processor.ProcessingMode;
@@ -109,9 +109,9 @@ public abstract class AbstractRecordTable extends Table {
             } else {
                 add(records);
             }
-        } catch (ConnectionUnavailableException e) { // TODO: 2020-09-25 search about handling other DB errors 
+        } catch (ConnectionUnavailableException e) {
             onAddError(addingEventChunk, e, ErrorOccurrence.STORE_ON_TABLE_ADD, true);
-        } catch (SiddhiAppRuntimeException e) { // TODO: 2020-09-28 introduce a new runtime error 
+        } catch (DatabaseConstraintViolationException e) {
             onAddError(addingEventChunk, e, ErrorOccurrence.STORE_ON_TABLE_ADD, false);
         }
         // TODO: 2020-09-25 catch  SiddhiAppRuntimeException and validate for RDBMS constraint violation exception

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ReplayableTableRecord.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ReplayableTableRecord.java
@@ -36,6 +36,7 @@ public class ReplayableTableRecord implements Serializable {
     private StateEvent stateEvent;
     private CompiledUpdateSet compiledUpdateSet;
     private AddingStreamEventExtractor addingStreamEventExtractor;
+    private boolean isFromConnectionUnavailableException = true;
 
     /**
      * For onAddError
@@ -132,5 +133,13 @@ public class ReplayableTableRecord implements Serializable {
 
     public AddingStreamEventExtractor getAddingStreamEventExtractor() {
         return addingStreamEventExtractor;
+    }
+
+    public boolean isFromConnectionUnavailableException() {
+        return isFromConnectionUnavailableException;
+    }
+
+    public void setFromConnectionUnavailableException(boolean fromConnectionUnavailableException) {
+        isFromConnectionUnavailableException = fromConnectionUnavailableException;
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ReplayableTableRecord.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ReplayableTableRecord.java
@@ -37,7 +37,7 @@ public class ReplayableTableRecord implements Serializable {
     private CompiledUpdateSet compiledUpdateSet;
     private AddingStreamEventExtractor addingStreamEventExtractor;
     private boolean isFromConnectionUnavailableException = true;
-    private boolean isEditable; // TODO: 2020-09-29 make false is any column of table is object 
+    private boolean isEditable;
 
     /**
      * For onAddError

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ReplayableTableRecord.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ReplayableTableRecord.java
@@ -37,6 +37,7 @@ public class ReplayableTableRecord implements Serializable {
     private CompiledUpdateSet compiledUpdateSet;
     private AddingStreamEventExtractor addingStreamEventExtractor;
     private boolean isFromConnectionUnavailableException = true;
+    private boolean isEditable; // TODO: 2020-09-29 make false is any column of table is object 
 
     /**
      * For onAddError

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ReplayableTableRecord.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/model/ReplayableTableRecord.java
@@ -143,4 +143,12 @@ public class ReplayableTableRecord implements Serializable {
     public void setFromConnectionUnavailableException(boolean fromConnectionUnavailableException) {
         isFromConnectionUnavailableException = fromConnectionUnavailableException;
     }
+
+    public boolean isEditable() {
+        return isEditable;
+    }
+
+    public void setEditable(boolean editable) {
+        isEditable = editable;
+    }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/util/ErrorHandlerUtils.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/util/ErrorHandlerUtils.java
@@ -25,6 +25,7 @@ import com.google.gson.JsonPrimitive;
 import io.siddhi.core.event.ComplexEventChunk;
 import io.siddhi.core.event.state.StateEvent;
 import io.siddhi.core.event.stream.StreamEvent;
+import io.siddhi.core.exception.ConnectionUnavailableException;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.definition.TableDefinition;
 
@@ -71,9 +72,14 @@ public class ErrorHandlerUtils {
     }
 
     public static String constructAddErrorRecordString(ComplexEventChunk<StreamEvent> eventChunk,
-                                                       boolean isObjectColumnPresent, TableDefinition tableDefinition) {
+                                                       boolean isObjectColumnPresent, TableDefinition tableDefinition,
+                                                       Exception e) {
         JsonObject payloadJson = new JsonObject();
-        payloadJson.addProperty("isEditable", !isObjectColumnPresent);
+        if (isObjectColumnPresent || e instanceof ConnectionUnavailableException) {
+            payloadJson.addProperty("isEditable", false);
+        } else {
+            payloadJson.addProperty("isEditable", true);
+        }
         JsonArray attributes = new JsonArray();
         JsonArray records = new JsonArray();
         for (Attribute attribute : tableDefinition.getAttributeList()) {
@@ -99,9 +105,14 @@ public class ErrorHandlerUtils {
     }
 
     public static String constructErrorRecordString(ComplexEventChunk<StateEvent> eventChunk,
-                                                    boolean isObjectColumnPresent, TableDefinition tableDefinition) {
+                                                    boolean isObjectColumnPresent, TableDefinition tableDefinition,
+                                                    Exception e) {
         JsonObject payloadJson = new JsonObject();
-        payloadJson.addProperty("isEditable", !isObjectColumnPresent);
+        if (isObjectColumnPresent || e instanceof ConnectionUnavailableException) {
+            payloadJson.addProperty("isEditable", false);
+        } else {
+            payloadJson.addProperty("isEditable", true);
+        }
         JsonArray attributes = new JsonArray();
         JsonArray records = new JsonArray();
         for (Attribute attribute : tableDefinition.getAttributeList()) {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/util/ErrorHandlerUtils.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/util/ErrorHandlerUtils.java
@@ -91,8 +91,9 @@ public class ErrorHandlerUtils {
             for (Object item : streamEvent.getOutputData()) {
                 if (item == null) {
                     record.add(JsonNull.INSTANCE);
+                } else {
+                    record.add(String.valueOf(item));
                 }
-                record.add(String.valueOf(item));
             }
             records.add(record);
         }
@@ -126,8 +127,9 @@ public class ErrorHandlerUtils {
                     for (Object item : streamEvent.getOutputData()) {
                         if (item == null) {
                             record.add(JsonNull.INSTANCE);
+                        } else {
+                            record.add(String.valueOf(item));
                         }
-                        record.add(String.valueOf(item));
                     }
                     records.add(record);
                 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/util/ErrorHandlerUtils.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/util/ErrorHandlerUtils.java
@@ -75,11 +75,7 @@ public class ErrorHandlerUtils {
                                                        boolean isObjectColumnPresent, TableDefinition tableDefinition,
                                                        Exception e) {
         JsonObject payloadJson = new JsonObject();
-        if (isObjectColumnPresent || e instanceof ConnectionUnavailableException) {
-            payloadJson.addProperty("isEditable", false);
-        } else {
-            payloadJson.addProperty("isEditable", true);
-        }
+        payloadJson.addProperty("isEditable", !(isObjectColumnPresent || e instanceof ConnectionUnavailableException));
         JsonArray attributes = new JsonArray();
         JsonArray records = new JsonArray();
         for (Attribute attribute : tableDefinition.getAttributeList()) {


### PR DESCRIPTION
## Purpose
This PR adds support for catching and storing database violation errors such as 
* Primary Key Violation
* Not Null Violation
* Foreign Key Violation.

These errors will be caught and persisted in the error database with a JSON string containing all relevant information. This saved event can be replayed from the error store explorer. The detailed info dialog box looks as follows,
![Screenshot 2020-10-06 at 15 41 24](https://user-images.githubusercontent.com/24491207/95188749-83ce2900-07ea-11eb-8f92-40fee050465b.png)


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/siddhi-io/siddhi/pull/1682
https://github.com/wso2/carbon-analytics/pull/1900

## Test environment
MacOS Catalina 10.15.6, JDK 1.8.0_201