### PR TITLE
Add Persisted Aggregation implementation

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -288,5 +288,14 @@
         <Package name="~io\.siddhi\.sample.*"/>
     </Match>
 
+    <Match>
+        <Class name="io.siddhi.core.aggregation.persistedaggregation.config.DBAggregationQueryConfiguration"/>
+        <Bug pattern="EI_EXPOSE_REP, EI_EXPOSE_REP2"/>
+    </Match>
+
+    <Match>
+        <Class name="io.siddhi.core.aggregation.persistedaggregation.config.DBAggregationQueryUtil"/>
+        <Bug pattern="LI_LAZY_INIT_STATIC"/>
+    </Match>
 
 </FindBugsFilter>

--- a/modules/siddhi-core/pom.xml
+++ b/modules/siddhi-core/pom.xml
@@ -121,7 +121,8 @@
                             *;resolution:=optional
                         </Import-Package>
                         <Include-Resource>
-                            META-INF=target/classes/META-INF
+                            META-INF=target/classes/META-INF,
+                            {maven-resources}
                         </Include-Resource>
                         <_dsannotations>*</_dsannotations>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/SiddhiAppRuntime.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/SiddhiAppRuntime.java
@@ -19,6 +19,7 @@
 package io.siddhi.core;
 
 import com.lmax.disruptor.ExceptionHandler;
+import io.siddhi.core.aggregation.AggregationRuntime;
 import io.siddhi.core.debugger.SiddhiDebugger;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.CannotClearSiddhiAppStateException;
@@ -89,6 +90,8 @@ public interface SiddhiAppRuntime {
      * @return Map of {@link AggregationDefinition}s.
      */
     Map<String, AggregationDefinition> getAggregationDefinitionMap();
+
+    Map<String, AggregationRuntime> getAggregationMap();
 
     /**
      * Get the names of the available queries.

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/SiddhiAppRuntimeImpl.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/SiddhiAppRuntimeImpl.java
@@ -241,6 +241,10 @@ public class SiddhiAppRuntimeImpl implements SiddhiAppRuntime {
                         e -> (AggregationDefinition) e.getValue()));
     }
 
+    public Map<String, AggregationRuntime> getAggregationMap() {
+        return aggregationMap;
+    }
+
     /**
      * Get the names of the available queries.
      *

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/BaseIncrementalValueStore.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/BaseIncrementalValueStore.java
@@ -28,6 +28,7 @@ import io.siddhi.core.util.snapshot.state.PartitionSyncStateHolder;
 import io.siddhi.core.util.snapshot.state.SingleSyncStateHolder;
 import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateHolder;
+import org.apache.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.List;
@@ -38,6 +39,7 @@ import java.util.Map;
  * the base incremental values would be sum and count. The timestamp too is stored here.
  */
 public class BaseIncrementalValueStore {
+    private static final Logger log = Logger.getLogger(BaseIncrementalValueStore.class);
     private StateHolder<ValueState> valueStateHolder;
     private StateHolder<StoreState> storeStateHolder;
 
@@ -55,7 +57,6 @@ public class BaseIncrementalValueStore {
         this.initialTimestamp = initialTimestamp;
         this.expressionExecutors = expressionExecutors;
         this.shouldUpdateTimestamp = shouldUpdateTimestamp;
-
         this.streamEventFactory = streamEventFactory;
 
         if (!local) {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/Executor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/Executor.java
@@ -55,4 +55,5 @@ public interface Executor {
      */
     void setNextExecutor(Executor executor);
 
+    void setEmitTime(long emitTimeOfLatestEventInTable);
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalExecutor.java
@@ -124,8 +124,6 @@ public class IncrementalExecutor implements Executor {
                 executorState.startTimeOfAggregates = IncrementalTimeConverterUtil.getStartTimeOfAggregates(
                         timestamp, duration, timeZone);
                 if (timestamp >= executorState.nextEmitTime) {
-                    LOG.info("Aggregation event dispatching for duration " + duration + " from " + startTime + " to " +
-                            timestamp);
                     executorState.nextEmitTime = IncrementalTimeConverterUtil.getNextEmitTime(
                             timestamp, duration, timeZone);
                     dispatchAggregateEvents(executorState.startTimeOfAggregates);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalExecutor.java
@@ -211,8 +211,6 @@ public class IncrementalExecutor implements Executor {
             for (StreamEvent event : tableStreamEventMap.values()) {
                 tableEventChunk.add(event);
             }
-            LOG.info("Aggregation data is persisting to database table " + table.getTableDefinition().getId() +
-                    " event timestamp " + eventChunk.getFirst().getTimestamp());
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Event dispatched by " + this.duration + " incremental executor: " + eventChunk.toString());
             }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalExecutor.java
@@ -15,7 +15,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package io.siddhi.core.aggregation;
 
 import io.siddhi.core.config.SiddhiAppContext;
@@ -41,6 +40,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Incremental executor class which is responsible for performing incremental aggregation.
@@ -53,6 +55,8 @@ public class IncrementalExecutor implements Executor {
     private final ExpressionExecutor timestampExpressionExecutor;
     private final StateHolder<ExecutorState> stateHolder;
     private final String siddhiAppName;
+    private final Lock lock = new ReentrantLock();
+    boolean waitUntillprocessFinish = false;
     private TimePeriod.Duration duration;
     private Table table;
     private boolean isRoot;
@@ -63,15 +67,15 @@ public class IncrementalExecutor implements Executor {
     private Scheduler scheduler;
     private ExecutorService executorService;
     private String timeZone;
-
     private BaseIncrementalValueStore baseIncrementalValueStore;
+
 
     public IncrementalExecutor(String aggregatorName, TimePeriod.Duration duration,
                                List<ExpressionExecutor> processExpressionExecutors,
                                ExpressionExecutor shouldUpdateTimestamp, GroupByKeyGenerator groupByKeyGenerator,
-                               boolean isRoot, Table table, IncrementalExecutor child,
+                               boolean isRoot, Table table, Executor child,
                                SiddhiQueryContext siddhiQueryContext, MetaStreamEvent metaStreamEvent,
-                               String timeZone) {
+                               String timeZone, boolean waitUntillprocessFinish) {
         this.timeZone = timeZone;
         this.aggregatorName = aggregatorName;
         this.duration = duration;
@@ -79,6 +83,7 @@ public class IncrementalExecutor implements Executor {
         this.table = table;
         this.next = child;
 
+        this.waitUntillprocessFinish = waitUntillprocessFinish;
         this.timestampExpressionExecutor = processExpressionExecutors.remove(0);
         this.streamEventFactory = new StreamEventFactory(metaStreamEvent);
 
@@ -115,9 +120,12 @@ public class IncrementalExecutor implements Executor {
             ExecutorState executorState = stateHolder.getState();
             try {
                 long timestamp = getTimestamp(streamEvent, executorState);
+                long startTime = executorState.startTimeOfAggregates;
                 executorState.startTimeOfAggregates = IncrementalTimeConverterUtil.getStartTimeOfAggregates(
                         timestamp, duration, timeZone);
                 if (timestamp >= executorState.nextEmitTime) {
+                    LOG.info("Aggregation event dispatching for duration " + duration + " from " + startTime + " to " +
+                            timestamp);
                     executorState.nextEmitTime = IncrementalTimeConverterUtil.getNextEmitTime(
                             timestamp, duration, timeZone);
                     dispatchAggregateEvents(executorState.startTimeOfAggregates);
@@ -193,6 +201,7 @@ public class IncrementalExecutor implements Executor {
     }
 
     private void dispatchEvent(long startTimeOfNewAggregates, BaseIncrementalValueStore aBaseIncrementalValueStore) {
+        AtomicBoolean isProcessFinished = new AtomicBoolean(false);
         if (aBaseIncrementalValueStore.isProcessed()) {
             Map<String, StreamEvent> streamEventMap = aBaseIncrementalValueStore.getGroupedByEvents();
             ComplexEventChunk<StreamEvent> eventChunk = new ComplexEventChunk<>();
@@ -204,21 +213,33 @@ public class IncrementalExecutor implements Executor {
             for (StreamEvent event : tableStreamEventMap.values()) {
                 tableEventChunk.add(event);
             }
+            LOG.info("Aggregation data is persisting to database table " + table.getTableDefinition().getId() +
+                    " event timestamp " + eventChunk.getFirst().getTimestamp());
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Event dispatched by " + this.duration + " incremental executor: " + eventChunk.toString());
             }
             if (isProcessingExecutor) {
-                executorService.execute(() -> {
-                            try {
-                                table.addEvents(tableEventChunk, streamEventMap.size());
-                            } catch (Throwable t) {
-                                LOG.error("Exception occurred at siddhi app '" + this.siddhiAppName +
-                                        "' when performing table writes of aggregation '" + this.aggregatorName +
-                                        "' for duration '" + this.duration + "'. This should be investigated as this " +
-                                        "can cause accuracy loss.", t);
-                            }
-                        }
-                );
+                try {
+                    executorService.execute(() -> {
+                        table.addEvents(tableEventChunk, streamEventMap.size());
+                        isProcessFinished.set(true);
+                    });
+                } catch (Throwable t) {
+                    LOG.error("Exception occurred at siddhi app '" + this.siddhiAppName +
+                            "' when performing table writes of aggregation '" + this.aggregatorName +
+                            "' for duration '" + this.duration + "'. This should be investigated as this " +
+                            "can cause accuracy loss.", t);
+                }
+            }
+            if (waitUntillprocessFinish) {
+                try {
+                    while (!isProcessFinished.get()) {
+                        Thread.sleep(1000);
+                    }
+                } catch (InterruptedException e) {
+                    LOG.error("Error occurred while waiting until table update task finishes for duration " +
+                            duration, e);
+                }
             }
             if (getNextExecutor() != null) {
                 next.execute(eventChunk);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalExecutorsInitialiser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/IncrementalExecutorsInitialiser.java
@@ -50,7 +50,7 @@ import static io.siddhi.core.util.SiddhiConstants.AGG_START_TIMESTAMP_COL;
 public class IncrementalExecutorsInitialiser {
     private final List<TimePeriod.Duration> incrementalDurations;
     private final Map<TimePeriod.Duration, Table> aggregationTables;
-    private final Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap;
+    private final Map<TimePeriod.Duration, Executor> incrementalExecutorMap;
 
     private final boolean isDistributed;
     private final String shardId;
@@ -67,7 +67,7 @@ public class IncrementalExecutorsInitialiser {
 
     public IncrementalExecutorsInitialiser(List<TimePeriod.Duration> incrementalDurations,
                                            Map<TimePeriod.Duration, Table> aggregationTables,
-                                           Map<TimePeriod.Duration, IncrementalExecutor> incrementalExecutorMap,
+                                           Map<TimePeriod.Duration, Executor> incrementalExecutorMap,
                                            boolean isDistributed, String shardId, SiddhiAppContext siddhiAppContext,
                                            MetaStreamEvent metaStreamEvent, Map<String, Table> tableMap,
                                            Map<String, Window> windowMap,
@@ -112,10 +112,9 @@ public class IncrementalExecutorsInitialiser {
             endOFLatestEventTimestamp = IncrementalTimeConverterUtil
                     .getNextEmitTime(lastData, incrementalDurations.get(incrementalDurations.size() - 1), timeZone);
         }
-
         for (int i = incrementalDurations.size() - 1; i > 0; i--) {
             TimePeriod.Duration recreateForDuration = incrementalDurations.get(i);
-            IncrementalExecutor incrementalExecutor = incrementalExecutorMap.get(recreateForDuration);
+            Executor incrementalExecutor = incrementalExecutorMap.get(recreateForDuration);
 
 
             // Get the table previous to the duration for which we need to recreate (e.g. if we want to recreate
@@ -145,7 +144,7 @@ public class IncrementalExecutorsInitialiser {
 
                 if (i == 1) {
                     TimePeriod.Duration rootDuration = incrementalDurations.get(0);
-                    IncrementalExecutor rootIncrementalExecutor = incrementalExecutorMap.get(rootDuration);
+                    Executor rootIncrementalExecutor = incrementalExecutorMap.get(rootDuration);
                     long emitTimeOfLatestEventInTable = IncrementalTimeConverterUtil.getNextEmitTime(
                             referenceToNextLatestEvent, rootDuration, timeZone);
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/PersistedIncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/PersistedIncrementalExecutor.java
@@ -146,8 +146,8 @@ public class PersistedIncrementalExecutor implements Executor {
                             try {
                                 Thread.sleep(3000);
                             } catch (InterruptedException interruptedException) {
-                                log.error("Thread sleep interrupted while waiting to re-execute the aggregation query " +
-                                        "for duration " + duration, interruptedException);
+                                log.error("Thread sleep interrupted while waiting to re-execute the " +
+                                        "aggregation query for duration " + duration, interruptedException);
                             }
                             continue;
                         }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/PersistedIncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/PersistedIncrementalExecutor.java
@@ -143,12 +143,18 @@ public class PersistedIncrementalExecutor implements Executor {
                             log.error("Error occurred while executing the aggregation for data between " +
                                     startTimeOfNewAggregates + " - " + emittedTime + " for duration " + duration +
                                     " Retrying the transaction attempt " + (i - 1), e);
+                            try {
+                                Thread.sleep(3000);
+                            } catch (InterruptedException interruptedException) {
+                                log.error("Thread sleep interrupted while waiting to re-execute the aggregation query " +
+                                        "for duration " + duration, interruptedException);
+                            }
                             continue;
                         }
                         log.error("Error occurred while executing the aggregation for data between "
                                 + startTimeOfNewAggregates + " - " + emittedTime + " for duration " + duration +
-                                " Retry attempts  " + (i - 1) + " This Should be investigated since this will lead " +
-                                "to a data mismatch\n", e);
+                                ". Attempted re-executing the query for 9 seconds. " +
+                                "This Should be investigated since this will lead to a data mismatch\n", e);
                     } else {
                         log.error("Error occurred while executing the aggregation for data between "
                                 + startTimeOfNewAggregates + " - " + emittedTime + " for duration \n" + duration, e);

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/PersistedIncrementalExecutor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/PersistedIncrementalExecutor.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.aggregation.persistedaggregation;
+
+import io.siddhi.core.aggregation.Executor;
+import io.siddhi.core.config.SiddhiQueryContext;
+import io.siddhi.core.event.ComplexEvent;
+import io.siddhi.core.event.ComplexEventChunk;
+import io.siddhi.core.event.stream.MetaStreamEvent;
+import io.siddhi.core.event.stream.StreamEvent;
+import io.siddhi.core.event.stream.StreamEventFactory;
+import io.siddhi.core.executor.ExpressionExecutor;
+import io.siddhi.core.query.processor.Processor;
+import io.siddhi.core.util.IncrementalTimeConverterUtil;
+import io.siddhi.core.util.snapshot.state.State;
+import io.siddhi.core.util.snapshot.state.StateHolder;
+import io.siddhi.query.api.aggregation.TimePeriod;
+import org.apache.log4j.Logger;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Incremental Executor implementation class for Persisted Aggregation
+ **/
+public class PersistedIncrementalExecutor implements Executor {
+    private static final Logger log = Logger.getLogger(PersistedIncrementalExecutor.class);
+
+    private final ExpressionExecutor timestampExpressionExecutor;
+    private final StateHolder<ExecutorState> stateHolder;
+    private TimePeriod.Duration duration;
+    private Executor next;
+    private StreamEventFactory streamEventFactory;
+    private String timeZone;
+    private Processor cudStreamProcessor;
+    private boolean isProcessingExecutor;
+
+    public PersistedIncrementalExecutor(String aggregatorName, TimePeriod.Duration duration,
+                                        List<ExpressionExecutor> processExpressionExecutors,
+                                        Executor child, SiddhiQueryContext siddhiQueryContext,
+                                        MetaStreamEvent metaStreamEvent, String timeZone,
+                                        Processor cudStreamProcessor) {
+        this.timeZone = timeZone;
+        this.duration = duration;
+        this.next = child;
+        this.cudStreamProcessor = cudStreamProcessor;
+
+        this.timestampExpressionExecutor = processExpressionExecutors.remove(0);
+        this.streamEventFactory = new StreamEventFactory(metaStreamEvent);
+        setNextExecutor(child);
+
+        this.stateHolder = siddhiQueryContext.generateStateHolder(
+                aggregatorName + "-" + this.getClass().getName(), false,
+                () -> new ExecutorState());
+        this.isProcessingExecutor = false;
+    }
+
+    @Override
+    public void execute(ComplexEventChunk streamEventChunk) {
+        if (log.isDebugEnabled()) {
+            log.debug("Event Chunk received by " + this.duration + " incremental executor: " +
+                    streamEventChunk.toString() + " will be dropped since persisted aggregation has been scheduled ");
+        }
+        streamEventChunk.reset();
+        while (streamEventChunk.hasNext()) {
+            StreamEvent streamEvent = (StreamEvent) streamEventChunk.next();
+            streamEventChunk.remove();
+            ExecutorState executorState = stateHolder.getState();
+            try {
+                long timestamp = getTimestamp(streamEvent);
+                if (timestamp >= executorState.nextEmitTime) {
+                    long emittedTime = executorState.nextEmitTime;
+                    long startedTime = executorState.startTimeOfAggregates;
+                    executorState.startTimeOfAggregates = IncrementalTimeConverterUtil.getStartTimeOfAggregates(
+                            timestamp, duration, timeZone);
+                    executorState.nextEmitTime = IncrementalTimeConverterUtil.getNextEmitTime(
+                            timestamp, duration, timeZone);
+                    dispatchAggregateEvents(startedTime, emittedTime, timeZone);
+                    sendTimerEvent(executorState);
+                }
+            } finally {
+                stateHolder.returnState(executorState);
+            }
+        }
+    }
+
+    private void dispatchAggregateEvents(long startTimeOfNewAggregates, long emittedTime, String timeZone) {
+        if (emittedTime != -1) {
+            dispatchEvent(startTimeOfNewAggregates, emittedTime, timeZone);
+        }
+    }
+
+    private void dispatchEvent(long startTimeOfNewAggregates, long emittedTime, String timeZone) {
+        ZonedDateTime startTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(startTimeOfNewAggregates),
+                ZoneId.of(timeZone));
+        ZonedDateTime endTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(emittedTime),
+                ZoneId.of(timeZone));
+        log.info("Aggregation event dispatched for the duration " + duration + " to aggregate data from "
+                + startTime.toString() + " to " + endTime.toString() + " ");
+        ComplexEventChunk complexEventChunk = new ComplexEventChunk();
+        StreamEvent streamEvent = streamEventFactory.newInstance();
+        streamEvent.setType(ComplexEvent.Type.CURRENT);
+        streamEvent.setTimestamp(emittedTime);
+        List<Object> outputDataList = new ArrayList<>();
+        outputDataList.add(startTimeOfNewAggregates);
+        outputDataList.add(emittedTime);
+        outputDataList.add(null);
+        streamEvent.setOutputData(outputDataList.toArray());
+
+        if (isProcessingExecutor) {
+            complexEventChunk.add(streamEvent);
+            int i = 0;
+            while (true) {
+                i++;
+                try {
+                    cudStreamProcessor.process(complexEventChunk);
+                    return;
+                } catch (Exception e) {
+                    if (e.getCause() instanceof SQLException) {
+                        if (e.getCause().getLocalizedMessage().contains("try restarting transaction") && i < 3) {
+                            log.error("Error occurred while executing the aggregation for data between " +
+                                    startTimeOfNewAggregates + " - " + emittedTime + " for duration " + duration +
+                                    " Retrying the transaction attempt " + (i - 1), e);
+                            continue;
+                        }
+                        log.error("Error occurred while executing the aggregation for data between "
+                                + startTimeOfNewAggregates + " - " + emittedTime + " for duration " + duration +
+                                " Retry attempts  " + (i - 1) + " This Should be investigated since this will lead " +
+                                "to a data mismatch\n", e);
+                    } else {
+                        log.error("Error occurred while executing the aggregation for data between "
+                                + startTimeOfNewAggregates + " - " + emittedTime + " for duration \n" + duration, e);
+                    }
+                    return;
+                }
+            }
+        }
+        if (getNextExecutor() != null) {
+            next.execute(complexEventChunk);
+        }
+    }
+
+    public void setEmitTime(long emitTimeOfLatestEventInTable) {
+        ExecutorState state = stateHolder.getState();
+        try {
+            state.nextEmitTime = emitTimeOfLatestEventInTable;
+        } finally {
+            stateHolder.returnState(state);
+        }
+    }
+
+    public void setProcessingExecutor(boolean processingExecutor) {
+        isProcessingExecutor = processingExecutor;
+    }
+
+    private void sendTimerEvent(ExecutorState executorState) {
+        if (getNextExecutor() != null) {
+            StreamEvent timerEvent = streamEventFactory.newInstance();
+            timerEvent.setType(ComplexEvent.Type.TIMER);
+            timerEvent.setTimestamp(executorState.startTimeOfAggregates);
+            ComplexEventChunk<StreamEvent> timerStreamEventChunk = new ComplexEventChunk<>();
+            timerStreamEventChunk.add(timerEvent);
+            next.execute(timerStreamEventChunk);
+        }
+    }
+
+    private long getTimestamp(StreamEvent streamEvent) {
+        long timestamp;
+        if (streamEvent.getType() == ComplexEvent.Type.CURRENT) {
+            timestamp = (long) timestampExpressionExecutor.execute(streamEvent);
+        } else {
+            timestamp = streamEvent.getTimestamp();
+        }
+        return timestamp;
+    }
+
+    @Override
+    public Executor getNextExecutor() {
+        return next;
+    }
+
+    @Override
+    public void setNextExecutor(Executor executor) {
+        next = executor;
+    }
+
+    class ExecutorState extends State {
+        private long nextEmitTime = -1;
+        private long startTimeOfAggregates = -1;
+        private boolean timerStarted = false;
+        private boolean canDestroy = false;
+
+        @Override
+        public boolean canDestroy() {
+            return canDestroy;
+        }
+
+        @Override
+        public Map<String, Object> snapshot() {
+            Map<String, Object> state = new HashMap<>();
+            state.put("NextEmitTime", nextEmitTime);
+            state.put("StartTimeOfAggregates", startTimeOfAggregates);
+            state.put("TimerStarted", timerStarted);
+            return state;
+        }
+
+        @Override
+        public void restore(Map<String, Object> state) {
+            nextEmitTime = (long) state.get("NextEmitTime");
+            startTimeOfAggregates = (long) state.get("StartTimeOfAggregates");
+            timerStarted = (boolean) state.get("TimerStarted");
+        }
+
+        public void setCanDestroy(boolean canDestroy) {
+            this.canDestroy = canDestroy;
+        }
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationQueryConfiguration.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationQueryConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.aggregation.persistedaggregation.config;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * This class represents the JAXB bean for the query configuration which provide a link between RDBMS Event Table
+ * functions and DB vendor-specific SQL syntax.
+ */
+@XmlRootElement(name = "rdbms-table-configuration")
+public class DBAggregationQueryConfiguration {
+
+    private DBAggregationQueryConfigurationEntry[] databases;
+
+    @XmlElement(name = "database")
+    public DBAggregationQueryConfigurationEntry[] getDatabases() {
+        return databases;
+    }
+
+    public void setDatabases(DBAggregationQueryConfigurationEntry[] databases) {
+        this.databases = databases;
+    }
+
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationQueryConfigurationEntry.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationQueryConfigurationEntry.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.aggregation.persistedaggregation.config;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * This class contains all the Siddhi RDBMS Event Table SQL query configuration mappings.
+ */
+@XmlRootElement(name = "database")
+public class DBAggregationQueryConfigurationEntry {
+
+    private String databaseName;
+    private String category;
+    private double minVersion;
+    private double maxVersion;
+    private String stringSize;
+    private int fieldSizeLimit;
+    private RDBMSTypeMapping rdbmsTypeMapping;
+    private DBAggregationSelectQueryTemplate dbAggregationSelectQueryTemplate;
+    private DBAggregationSelectFunctionTemplate dbAggregationSelectFunctionTemplate;
+    private DBAggregationTimeConversionDurationMapping dbAggregationTimeConversionDurationMapping;
+    private int batchSize;
+    private boolean batchEnable = false;
+    private String collation;
+    private boolean transactionSupported = true;
+
+    @XmlAttribute(name = "name", required = true)
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public void setDatabaseName(String databaseName) {
+        this.databaseName = databaseName;
+    }
+
+    @XmlAttribute(name = "minVersion")
+    public double getMinVersion() {
+        return minVersion;
+    }
+
+    public void setMinVersion(double minVersion) {
+        this.minVersion = minVersion;
+    }
+
+    @XmlAttribute(name = "maxVersion")
+    public double getMaxVersion() {
+        return maxVersion;
+    }
+
+    public void setMaxVersion(double maxVersion) {
+        this.maxVersion = maxVersion;
+    }
+
+    @XmlAttribute(name = "category")
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    @XmlElement(name = "batchEnable")
+    public boolean getBatchEnable() {
+        return batchEnable;
+    }
+
+    public void setBatchEnable(boolean batchEnable) {
+        this.batchEnable = batchEnable;
+    }
+
+    @XmlElement(name = "collation")
+    public String getCollation() {
+        return collation;
+    }
+
+    public void setCollation(String collation) {
+        this.collation = collation;
+    }
+
+    public String getStringSize() {
+        return stringSize;
+    }
+
+    public void setStringSize(String stringSize) {
+        this.stringSize = stringSize;
+    }
+
+    public boolean isTransactionSupported() {
+        return transactionSupported;
+    }
+
+    public void setTransactionSupported(boolean transactionSupported) {
+        this.transactionSupported = transactionSupported;
+    }
+
+    @XmlElement(name = "typeMapping", required = true)
+    public RDBMSTypeMapping getRdbmsTypeMapping() {
+        return rdbmsTypeMapping;
+    }
+
+    public void setRdbmsTypeMapping(RDBMSTypeMapping rdbmsTypeMapping) {
+        this.rdbmsTypeMapping = rdbmsTypeMapping;
+    }
+
+    @XmlElement(name = "selectQueryTemplate")
+    public DBAggregationSelectQueryTemplate getRdbmsSelectQueryTemplate() {
+        return dbAggregationSelectQueryTemplate;
+    }
+
+    public void setRdbmsSelectQueryTemplate(DBAggregationSelectQueryTemplate dbAggregationSelectQueryTemplate) {
+        this.dbAggregationSelectQueryTemplate = dbAggregationSelectQueryTemplate;
+    }
+
+    @XmlElement(name = "batchSize", required = true)
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    @XmlElement(name = "fieldSizeLimit", required = false)
+    public int getFieldSizeLimit() {
+        return fieldSizeLimit;
+    }
+
+    public void setFieldSizeLimit(int fieldSizeLimit) {
+        this.fieldSizeLimit = fieldSizeLimit;
+    }
+
+    @XmlElement(name = "selectQueryFunctions")
+    public DBAggregationSelectFunctionTemplate getRdbmsSelectFunctionTemplate() {
+        return dbAggregationSelectFunctionTemplate;
+    }
+
+    public void setRdbmsSelectFunctionTemplate(DBAggregationSelectFunctionTemplate
+                                                       dbAggregationSelectFunctionTemplate) {
+        this.dbAggregationSelectFunctionTemplate = dbAggregationSelectFunctionTemplate;
+    }
+
+    @XmlElement(name = "timeConversionDurationMapping")
+    public DBAggregationTimeConversionDurationMapping getDbAggregationTimeConversionDurationMapping() {
+        return dbAggregationTimeConversionDurationMapping;
+    }
+
+    public void setDbAggregationTimeConversionDurationMapping(
+            DBAggregationTimeConversionDurationMapping dbAggregationTimeConversionDurationMapping) {
+        this.dbAggregationTimeConversionDurationMapping = dbAggregationTimeConversionDurationMapping;
+    }
+}
+

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationQueryUtil.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationQueryUtil.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.aggregation.persistedaggregation.config;
+
+import com.google.common.collect.Maps;
+import io.siddhi.core.exception.CannotLoadConfigurationException;
+import io.siddhi.core.util.parser.AggregationParser;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+import static io.siddhi.core.util.SiddhiConstants.DB_AGGREGATION_CONFIG_FILE;
+/**
+ * Util class for reading persisted aggregation queries
+ * **/
+public class DBAggregationQueryUtil {
+
+    private static final Logger LOG = Logger.getLogger(DBAggregationQueryUtil.class);
+    private static DBAggregationConfigurationMapper mapper;
+
+    /**
+     * Isolates a particular RDBMS query configuration entry which matches the retrieved DB metadata.
+     *
+     * @param databaseType the database type against which the entry should be matched.
+     * @return the matching RDBMS query configuration entry.
+     * @throws CannotLoadConfigurationException if the configuration cannot be loaded.
+     */
+    public static DBAggregationQueryConfigurationEntry lookupCurrentQueryConfigurationEntry(
+            AggregationParser.Database databaseType) throws CannotLoadConfigurationException {
+        DBAggregationConfigurationMapper mapper = loadDBAggregationConfigurationMapper();
+        DBAggregationQueryConfigurationEntry entry = mapper.lookupEntry(databaseType.toString());
+        if (entry != null) {
+            return entry;
+        } else {
+            throw new CannotLoadConfigurationException("Cannot find a database section in the RDBMS "
+                    + "configuration for the database: " + databaseType);
+        }
+    }
+
+    /**
+     * Checks and returns an instance of the RDBMS query configuration mapper.
+     *
+     * @return an instance of {@link DBAggregationConfigurationMapper}.
+     * @throws CannotLoadConfigurationException if the configuration cannot be loaded.
+     */
+    private static DBAggregationConfigurationMapper loadDBAggregationConfigurationMapper()
+            throws CannotLoadConfigurationException {
+        if (mapper == null) {
+            synchronized (DBAggregationQueryUtil.class) {
+                DBAggregationQueryConfiguration config = loadQueryConfiguration();
+                mapper = new DBAggregationConfigurationMapper(config);
+            }
+        }
+        return mapper;
+    }
+
+    private static DBAggregationQueryConfiguration loadQueryConfiguration() throws CannotLoadConfigurationException {
+        return new DBAggregationConfigLoader().loadConfiguration();
+    }
+
+    /**
+     * RDBMS configuration mapping class to be used to lookup matching configuration entry with a data source.
+     */
+    private static class DBAggregationConfigurationMapper {
+
+        private List<Map.Entry<Pattern, DBAggregationQueryConfigurationEntry>> entries = new ArrayList<>();
+
+        public DBAggregationConfigurationMapper(DBAggregationQueryConfiguration config) {
+            for (DBAggregationQueryConfigurationEntry entry : config.getDatabases()) {
+                this.entries.add(Maps.immutableEntry(Pattern.compile(
+                        entry.getDatabaseName().toLowerCase(Locale.ENGLISH)), entry));
+            }
+        }
+
+        private List<DBAggregationQueryConfigurationEntry> extractMatchingConfigEntries(String dbName) {
+            List<DBAggregationQueryConfigurationEntry> result = new ArrayList<>();
+            this.entries.forEach(entry -> {
+                if (entry.getKey().matcher(dbName).find()) {
+                    result.add(entry.getValue());
+                }
+            });
+            return result;
+        }
+
+        public DBAggregationQueryConfigurationEntry lookupEntry(String dbName) {
+            List<DBAggregationQueryConfigurationEntry> dbResults = this.extractMatchingConfigEntries(
+                    dbName.toLowerCase(Locale.ENGLISH));
+            if (dbResults.isEmpty()) {
+                return null;
+            }
+            return dbResults.get(0);
+        }
+    }
+
+    /**
+     * Child class with a method for loading the JAXB configuration mappings.
+     */
+    private static class DBAggregationConfigLoader {
+
+        /**
+         * Method for loading the configuration mappings.
+         *
+         * @return an instance of {@link DBAggregationQueryConfiguration}.
+         * @throws CannotLoadConfigurationException if the config cannot be loaded.
+         */
+        private DBAggregationQueryConfiguration loadConfiguration() throws CannotLoadConfigurationException {
+            InputStream inputStream = null;
+            try {
+                JAXBContext ctx = JAXBContext.newInstance(DBAggregationQueryConfiguration.class);
+                Unmarshaller unmarshaller = ctx.createUnmarshaller();
+                ClassLoader classLoader = getClass().getClassLoader();
+                inputStream = classLoader.getResourceAsStream(DB_AGGREGATION_CONFIG_FILE);
+                if (inputStream == null) {
+                    throw new CannotLoadConfigurationException(DB_AGGREGATION_CONFIG_FILE
+                            + " is not found in the classpath");
+                }
+                return (DBAggregationQueryConfiguration) unmarshaller.unmarshal(inputStream);
+            } catch (JAXBException e) {
+                throw new CannotLoadConfigurationException(
+                        "Error in processing RDBMS query configuration: " + e.getMessage(), e);
+            } finally {
+                if (inputStream != null) {
+                    try {
+                        inputStream.close();
+                    } catch (IOException e) {
+                        LOG.error(String.format("Failed to close the input stream for %s", DB_AGGREGATION_CONFIG_FILE));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationSelectFunctionTemplate.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationSelectFunctionTemplate.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.aggregation.persistedaggregation.config;
+
+/**
+ * This class contains Select functions query configuration mappings.
+ */
+public class DBAggregationSelectFunctionTemplate {
+    private String sumFunction;
+    private String countFunction;
+    private String maxFunction;
+    private String minFunction;
+    private String timeConversionFunction;
+
+
+    public String getSumFunction() {
+        return sumFunction;
+    }
+
+    public void setSumFunction(String sumFunction) {
+        this.sumFunction = sumFunction;
+    }
+
+    public String getCountFunction() {
+        return countFunction;
+    }
+
+    public void setCountFunction(String countFunction) {
+        this.countFunction = countFunction;
+    }
+
+    public String getMaxFunction() {
+        return maxFunction;
+    }
+
+    public void setMaxFunction(String maxFunction) {
+        this.maxFunction = maxFunction;
+    }
+
+    public String getTimeConversionFunction() {
+        return timeConversionFunction;
+    }
+
+    public void setTimeConversionFunction(String timeConversionFunction) {
+        this.timeConversionFunction = timeConversionFunction;
+    }
+
+    public String getMinFunction() {
+        return minFunction;
+    }
+
+    public void setMinFunction(String minFunction) {
+        this.minFunction = minFunction;
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationSelectQueryTemplate.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationSelectQueryTemplate.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.aggregation.persistedaggregation.config;
+
+/**
+ * This class represents clauses of a SELECT query as required by Siddhi RDBMS Event Tables per supported DB vendor.
+ */
+public class DBAggregationSelectQueryTemplate {
+
+    private String selectClause;
+    private String recordInsertQuery;
+    private String selectQueryWithSubSelect;
+    private String selectQueryWithInnerSelect;
+    private String joinClause;
+    private String whereClause;
+    private String groupByClause;
+    private String havingClause;
+    private String orderByClause;
+    private String limitClause;
+    private String offsetClause;
+    private String queryWrapperClause;
+    private String limitWrapperClause;
+    private String offsetWrapperClause;
+    private String isLimitBeforeOffset;
+
+    public String getSelectClause() {
+        return selectClause;
+    }
+
+    public void setSelectClause(String selectClause) {
+        this.selectClause = selectClause;
+    }
+
+    public String getWhereClause() {
+        return whereClause;
+    }
+
+    public void setWhereClause(String whereClause) {
+        this.whereClause = whereClause;
+    }
+
+    public String getGroupByClause() {
+        return groupByClause;
+    }
+
+    public void setGroupByClause(String groupByClause) {
+        this.groupByClause = groupByClause;
+    }
+
+    public String getHavingClause() {
+        return havingClause;
+    }
+
+    public void setHavingClause(String havingClause) {
+        this.havingClause = havingClause;
+    }
+
+    public String getOrderByClause() {
+        return orderByClause;
+    }
+
+    public void setOrderByClause(String orderByClause) {
+        this.orderByClause = orderByClause;
+    }
+
+    public String getLimitClause() {
+        return limitClause;
+    }
+
+    public void setLimitClause(String limitClause) {
+        this.limitClause = limitClause;
+    }
+
+    public String getOffsetClause() {
+        return offsetClause;
+    }
+
+    public void setOffsetClause(String offsetClause) {
+        this.offsetClause = offsetClause;
+    }
+
+    public String getIsLimitBeforeOffset() {
+        return isLimitBeforeOffset;
+    }
+
+    public void setIsLimitBeforeOffset(String isLimitBeforeOffset) {
+        this.isLimitBeforeOffset = isLimitBeforeOffset;
+    }
+
+    public String getQueryWrapperClause() {
+        return queryWrapperClause;
+    }
+
+    public void setQueryWrapperClause(String queryWrapperClause) {
+        this.queryWrapperClause = queryWrapperClause;
+    }
+
+    public String getLimitWrapperClause() {
+        return limitWrapperClause;
+    }
+
+    public void setLimitWrapperClause(String limitWrapperClause) {
+        this.limitWrapperClause = limitWrapperClause;
+    }
+
+    public String getOffsetWrapperClause() {
+        return offsetWrapperClause;
+    }
+
+    public void setOffsetWrapperClause(String offsetWrapperClause) {
+        this.offsetWrapperClause = offsetWrapperClause;
+    }
+
+    public String getSelectQueryWithSubSelect() {
+        return selectQueryWithSubSelect;
+    }
+
+    public void setSelectQueryWithSubSelect(String selectQueryWithSubSelect) {
+        this.selectQueryWithSubSelect = selectQueryWithSubSelect;
+    }
+
+    public String getRecordInsertQuery() {
+        return recordInsertQuery;
+    }
+
+    public void setRecordInsertQuery(String recordInsertQuery) {
+        this.recordInsertQuery = recordInsertQuery;
+    }
+
+    public String getSelectQueryWithInnerSelect() {
+        return selectQueryWithInnerSelect;
+    }
+
+    public void setSelectQueryWithInnerSelect(String selectQueryWithInnerSelect) {
+        this.selectQueryWithInnerSelect = selectQueryWithInnerSelect;
+    }
+
+    public String getJoinClause() {
+        return joinClause;
+    }
+
+    public void setJoinClause(String joinClause) {
+        this.joinClause = joinClause;
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationTimeConversionDurationMapping.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/DBAggregationTimeConversionDurationMapping.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.aggregation.persistedaggregation.config;
+
+import io.siddhi.query.api.aggregation.TimePeriod;
+
+/**
+ * This class represents the duration objects that needed to pass in to time conversion function for each database type
+ * inorder to normalize the AGG_EVENT_TIMESTAMP
+ **/
+public class DBAggregationTimeConversionDurationMapping {
+    private String day;
+    private String month;
+    private String year;
+
+    public String getDay() {
+        return day;
+    }
+
+    public void setDay(String day) {
+        this.day = day;
+    }
+
+    public String getMonth() {
+        return month;
+    }
+
+    public void setMonth(String month) {
+        this.month = month;
+    }
+
+    public String getYear() {
+        return year;
+    }
+
+    public void setYear(String year) {
+        this.year = year;
+    }
+
+    public String getDurationMapping(TimePeriod.Duration duration) {
+        switch (duration) {
+            case DAYS:
+                return day;
+            case MONTHS:
+                return month;
+            case YEARS:
+                return year;
+            default:
+                //this won't get hit since persisted aggregators only will be created days and upward.
+                return "";
+        }
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/PersistedAggregationResultsProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/PersistedAggregationResultsProcessor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.aggregation.persistedaggregation.config;
+
+import io.siddhi.core.event.ComplexEvent;
+import io.siddhi.core.event.ComplexEventChunk;
+import io.siddhi.core.query.processor.Processor;
+import io.siddhi.query.api.aggregation.TimePeriod;
+import org.apache.log4j.Logger;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Processor implementation to read the results after executing the aggregation query
+ **/
+public class PersistedAggregationResultsProcessor implements Processor {
+    private static final Logger log = Logger.getLogger(PersistedAggregationResultsProcessor.class);
+    private TimePeriod.Duration duration;
+
+    public PersistedAggregationResultsProcessor(TimePeriod.Duration duration) {
+        this.duration = duration;
+    }
+
+    @Override
+    public void process(ComplexEventChunk complexEventChunk) {
+        if (complexEventChunk != null) {
+            ComplexEvent complexEvent = complexEventChunk.getFirst();
+            Object[] outputData = complexEvent.getOutputData();
+            if (outputData.length == 3) {
+                Date fromTime = new Date((Long) outputData[0]);
+                Date toTime = new Date((Long) outputData[1]);
+                log.info("Aggregation executed for duration " + duration + " from " + fromTime + " to " +
+                        toTime + " and  " + outputData[2] + " records has been successfully updated ");
+            }
+        }
+    }
+
+    @Override
+    public void process(List<ComplexEventChunk> complexEventChunks) {
+
+    }
+
+    @Override
+    public Processor getNextProcessor() {
+        return null;
+    }
+
+    @Override
+    public void setNextProcessor(Processor processor) {
+
+    }
+
+    @Override
+    public void setToLast(Processor processor) {
+
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/RDBMSTypeMapping.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/config/RDBMSTypeMapping.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.core.aggregation.persistedaggregation.config;
+
+/**
+ * This class represents the SQL datatype mappings required by Siddhi RDBMS Event Tables per supported DB vendor.
+ */
+public class RDBMSTypeMapping {
+
+    // -- Type mapping -- //
+    private String binaryType;
+    private String booleanType;
+    private String doubleType;
+    private String floatType;
+    private String integerType;
+    private String longType;
+    private String stringType;
+    private String bigStringType;
+
+    public String getBinaryType() {
+        return binaryType;
+    }
+
+    public void setBinaryType(String binaryType) {
+        this.binaryType = binaryType;
+    }
+
+    public String getBooleanType() {
+        return booleanType;
+    }
+
+    public void setBooleanType(String booleanType) {
+        this.booleanType = booleanType;
+    }
+
+    public String getDoubleType() {
+        return doubleType;
+    }
+
+    public void setDoubleType(String doubleType) {
+        this.doubleType = doubleType;
+    }
+
+    public String getFloatType() {
+        return floatType;
+    }
+
+    public void setFloatType(String floatType) {
+        this.floatType = floatType;
+    }
+
+    public String getIntegerType() {
+        return integerType;
+    }
+
+    public void setIntegerType(String integerType) {
+        this.integerType = integerType;
+    }
+
+    public String getLongType() {
+        return longType;
+    }
+
+    public void setLongType(String longType) {
+        this.longType = longType;
+    }
+
+    public String getStringType() {
+        return stringType;
+    }
+
+    public void setStringType(String stringType) {
+        this.stringType = stringType;
+    }
+
+    public String getBigStringType() {
+        return bigStringType;
+    }
+
+    public void setBigStringType(String bigStringType) {
+        this.bigStringType = bigStringType;
+    }
+}
+

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/event/stream/StreamEvent.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/event/stream/StreamEvent.java
@@ -18,6 +18,7 @@
 package io.siddhi.core.event.stream;
 
 import io.siddhi.core.event.ComplexEvent;
+import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -35,7 +36,7 @@ import static io.siddhi.core.util.SiddhiConstants.STREAM_ATTRIBUTE_TYPE_INDEX;
  * from StreamEvent before sending to relevant Queries.
  */
 public class StreamEvent implements ComplexEvent {
-
+    private static final Logger log = Logger.getLogger(StreamEvent.class);
     private static final long serialVersionUID = 8427059374772140103L;
     protected long timestamp = -1;
     protected Object[] outputData;              //Attributes to sent as output

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/input/stream/single/EntryValveExecutor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/input/stream/single/EntryValveExecutor.java
@@ -80,4 +80,8 @@ public class EntryValveExecutor implements Executor, Schedulable {
     public void process(ComplexEventChunk complexEventChunk) {
         execute(complexEventChunk);
     }
+
+    @Override
+    public void setEmitTime(long emitTimeOfLatestEventInTable) {
+    }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/selector/QuerySelector.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/selector/QuerySelector.java
@@ -78,7 +78,7 @@ public class QuerySelector implements Processor {
             log.trace("event is processed by selector " + id + this);
         }
         ComplexEventChunk outputComplexEventChunk = null;
-        if (complexEventChunk.isBatch() && batchingEnabled) {
+            if (complexEventChunk.isBatch() && batchingEnabled) {
             if (isGroupBy) {
                 outputComplexEventChunk = processInBatchGroupBy(complexEventChunk);
             } else if (containsAggregator) {

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/selector/attribute/aggregator/MaxAttributeAggregatorExecutor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/selector/attribute/aggregator/MaxAttributeAggregatorExecutor.java
@@ -70,6 +70,7 @@ public class MaxAttributeAggregatorExecutor
         extends AttributeAggregatorExecutor<MaxAttributeAggregatorExecutor.MaxAggregatorState> {
 
     private Attribute.Type returnType;
+    private ExpressionExecutor attributeExpressionExecutor;
 
     /**
      * The initialization method for FunctionExecutor
@@ -94,6 +95,7 @@ public class MaxAttributeAggregatorExecutor
         if (processingMode == ProcessingMode.SLIDE || outputExpectsExpiredEvents) {
             trackFutureStates = true;
         }
+        attributeExpressionExecutor = attributeExpressionExecutors[0];
         returnType = attributeExpressionExecutors[0].getReturnType();
         boolean finalTrackFutureStates = trackFutureStates;
         return () -> {
@@ -114,6 +116,10 @@ public class MaxAttributeAggregatorExecutor
 
     public Attribute.Type getReturnType() {
         return returnType;
+    }
+
+    public ExpressionExecutor getAttributeExpressionExecutor() {
+        return attributeExpressionExecutor;
     }
 
     @Override

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiConstants.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiConstants.java
@@ -31,6 +31,8 @@ public final class SiddhiConstants {
     public static final String NAMESPACE_SINK = "sink";
     public static final String NAMESPACE_SINK_MAPPER = "sinkMapper";
 
+    public static final String NAMESPACE_DISTINCT_COUNT_AGGREGATION_FUNCTION = "distinctCount";
+
     public static final String NAMESPACE_DISTRIBUTION_STRATEGY = "distributionStrategy";
     public static final String DISTRIBUTION_STRATEGY_PARTITIONED = "partitioned";
 
@@ -81,6 +83,7 @@ public final class SiddhiConstants {
     public static final String ANNOTATION_ELEMENT_INTERVAL = "interval";
     public static final String ANNOTATION_ELEMENT_INCLUDE = "include";
     public static final String ANNOTATION_PARTITION_BY_ID = "PartitionById";
+    public static final String ANNOTATION_PERSISTED_AGGREGATION = "persistedAggregation";
 
     public static final String TRUE = "true";
     public static final String TRIGGER_START = "start";
@@ -148,4 +151,33 @@ public final class SiddhiConstants {
 
     public static final String ENABLE_EVENT_COUNT_LOGGER = "enableLoggingEventCount";
     public static final String LOGGING_DURATION = "loggingDuration";
+
+    public static final String NAMESPACE_RDBMS = "rdbms";
+    public static final String FUNCTION_NAME_CUD = "cud";
+    public static final String DB_AGGREGATION_CONFIG_FILE = "db-aggregation-config.xml";
+    public static final String PLACEHOLDER_TABLE_NAME = "{{TABLE_NAME}}";
+    public static final String PLACEHOLDER_COLUMNS = "{{COLUMNS}}";
+    public static final String PLACEHOLDER_COLUMN = "{{COLUMN}}";
+    public static final String PLACEHOLDER_DURATION = "{{DURATION}}";
+    public static final String PLACEHOLDER_QUERY = "{{QUERY}}";
+    public static final String PLACEHOLDER_SELECTORS = "{{SELECTORS}}";
+    public static final String PLACEHOLDER_CONDITION = "{{CONDITION}}";
+    public static final String PLACEHOLDER_INNER_QUERY = "{{INNER_QUERY}}";
+    public static final String PLACEHOLDER_FROM_CONDITION = "{{FROM_CONDITION}}";
+
+    public static final String INSERT_TO_TABLE_NAME = "TO_TABLE_NAME";
+    public static final String FROM_TABLE_NAME = "FROM_TABLE_NAME";
+    public static final String UPDATED_TIMESTAMP = "UPDATED_TIMESTAMP";
+    public static final String FROM_TIMESTAMP = "FROM_TIMESTAMP";
+    public static final String TO_TIMESTAMP = "TO_TIMESTAMP";
+    public static final String SUB_SELECT_QUERY_REF_T2 = "t2";
+    public static final String SUB_SELECT_QUERY_REF_T1 = "t1";
+    public static final String EQUALS = " = ";
+    public static final String SQL_AS = " AS ";
+    public static final String SQL_AND = " AND ";
+    public static final String SQL_ON = " ON ";
+    public static final String SQL_SELECT = " SELECT ";
+    public static final String SQL_WHERE = " WHERE ";
+    public static final String SQL_FROM = " FROM ";
+
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
@@ -465,7 +465,8 @@ public class AggregationParser {
 
             IncrementalDataPurger incrementalDataPurger = new IncrementalDataPurger();
             incrementalDataPurger.init(aggregationDefinition, new StreamEventFactory(processedMetaStreamEvent)
-                    , aggregationTables, isProcessingOnExternalTime, siddhiQueryContext, aggregationDurations);
+                    , aggregationTables, isProcessingOnExternalTime, siddhiQueryContext, aggregationDurations, timeZone,
+                    windowMap, aggregationMap);
 
             //Recreate in-memory data from tables
             IncrementalExecutorsInitialiser incrementalExecutorsInitialiser = new IncrementalExecutorsInitialiser(
@@ -1224,7 +1225,8 @@ public class AggregationParser {
 
         if (isDistributed) {
             filterQueryBuilder.append(" AND ").append(AGG_SHARD_ID_COL).append(" = '").append(shardID).append("' ");
-            if (isProcessingOnExternalTime){
+            groupByQueryBuilder.add(AGG_SHARD_ID_COL);
+            if (isProcessingOnExternalTime) {
                 subSelectT1ColumnJoiner.add(AGG_SHARD_ID_COL);
             }
         }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
@@ -1396,11 +1396,8 @@ public class AggregationParser {
             return Database.ORACLE;
         } else if (databaseType.contains("mssql")) {
             return Database.MSSQL;
-        } else if (databaseType.contains("db2")) {
-            return Database.DB2;
-            //todo Need to fined a timeConversionFunction to handle external time base aggregation
-//        } else if (databaseType.contains("h2")) {
-//            return Database.H2;
+        } else if (databaseType.contains("postgres")) {
+            return Database.PostgreSQL;
         } else {
             log.warn("Provided database type " + databaseType + "is not recognized as a supported database type for" +
                     " persisted incremental aggregation, using MySQL as default ");
@@ -1480,6 +1477,7 @@ public class AggregationParser {
         ORACLE,
         MSSQL,
         DB2,
+        PostgreSQL,
         H2,
         DEFAULT
     }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/snapshot/state/PartitionStateHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/snapshot/state/PartitionStateHolder.java
@@ -160,6 +160,4 @@ public class PartitionStateHolder implements StateHolder {
             }
         }
     }
-
-
 }

--- a/modules/siddhi-core/src/main/resources/db-aggregation-config.xml
+++ b/modules/siddhi-core/src/main/resources/db-aggregation-config.xml
@@ -1,35 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <rdbms-table-configuration>
-<!--    <database name="h2">-->
-<!--        <selectQueryTemplate>-->
-<!--            <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}})</recordInsertQuery>-->
-<!--            <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>-->
-<!--            <whereClause>WHERE {{CONDITION}}</whereClause>-->
-<!--            <selectQueryWithInnerSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}} WHERE {{COLUMN}} IN ({{INNER_QUERY}})-->
-<!--            </selectQueryWithInnerSelect>-->
-<!--            <joinClause>SELECT {{SELECTORS}} FROM ({{FROM_CONDITION}}) AS t1 JOIN ({{INNER_QUERY}}) AS t2 ON {{CONDITION}}-->
-<!--            </joinClause>-->
-<!--            <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>-->
-<!--        </selectQueryTemplate>-->
-<!--        <selectQueryFunctions>-->
-<!--            <sumFunction>SUM({{COLUMN}})</sumFunction>-->
-<!--            <countFunction>COUNT({{COLUMN}})</countFunction>-->
-<!--            <maxFunction>MAX({{COLUMN}})</maxFunction>-->
-<!--            <minFunction>MIN({{COLUMN}})</minFunction>-->
-<!--        </selectQueryFunctions>-->
-<!--        <stringSize>254</stringSize>-->
-<!--        <batchEnable>true</batchEnable>-->
-<!--        <batchSize>1000</batchSize>-->
-<!--        <typeMapping>-->
-<!--            <binaryType>BLOB</binaryType>-->
-<!--            <booleanType>TINYINT(1)</booleanType>-->
-<!--            <doubleType>DOUBLE</doubleType>-->
-<!--            <floatType>FLOAT</floatType>-->
-<!--            <integerType>INTEGER</integerType>-->
-<!--            <longType>BIGINT</longType>-->
-<!--            <stringType>VARCHAR</stringType>-->
-<!--        </typeMapping>-->
-<!--    </database>-->
     <database name="mysql">
         <selectQueryTemplate>
             <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}})</recordInsertQuery>
@@ -172,65 +142,6 @@
             <booleanType>BOOLEAN</booleanType>
             <doubleType>DOUBLE PRECISION</doubleType>
             <floatType>REAL</floatType>
-            <integerType>INTEGER</integerType>
-            <longType>BIGINT</longType>
-            <stringType>VARCHAR</stringType>
-        </typeMapping>
-    </database>
-    <database name="DB2.*">
-        <selectQueryTemplate>
-            <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}})</recordInsertQuery>
-            <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <whereClause>WHERE {{CONDITION}}</whereClause>
-            <selectQueryWithInnerSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}} WHERE {{COLUMN}} IN ({{INNER_QUERY}})
-            </selectQueryWithInnerSelect>
-            <joinClause>SELECT {{SELECTORS}} FROM ({{FROM_CONDITION}}) AS t1 JOIN ({{INNER_QUERY}}) AS t2 ON {{CONDITION}}</joinClause>
-            <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
-        </selectQueryTemplate>
-        <selectQueryFunctions>
-            <sumFunction>SUM({{COLUMN}})</sumFunction>
-            <countFunction>COUNT({{COLUMN}})</countFunction>
-            <maxFunction>MAX({{COLUMN}})</maxFunction>
-            <minFunction>MIN({{COLUMN}})</minFunction>
-        </selectQueryFunctions>
-        <keyExplicitNotNull>true</keyExplicitNotNull>
-        <stringSize>254</stringSize>
-        <batchEnable>true</batchEnable>
-        <batchSize>1000</batchSize>
-        <typeMapping>
-            <binaryType>BLOB(64000)</binaryType>
-            <booleanType>SMALLINT</booleanType>
-            <doubleType>DOUBLE</doubleType>
-            <floatType>REAL</floatType>
-            <integerType>INTEGER</integerType>
-            <longType>BIGINT</longType>
-            <stringType>VARCHAR</stringType>
-        </typeMapping>
-    </database>
-    <database name="Apache Derby">
-        <selectQueryTemplate>
-            <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}})</recordInsertQuery>
-            <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <whereClause>WHERE {{CONDITION}}</whereClause>
-            <selectQueryWithInnerSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}} WHERE {{COLUMN}} IN ({{INNER_QUERY}})
-            </selectQueryWithInnerSelect>
-            <joinClause>SELECT {{SELECTORS}} FROM ({{FROM_CONDITION}}) AS t1 JOIN ({{INNER_QUERY}}) AS t2 ON {{CONDITION}}</joinClause>
-            <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
-        </selectQueryTemplate>
-        <selectQueryFunctions>
-            <sumFunction>SUM({{COLUMN}})</sumFunction>
-            <countFunction>COUNT({{COLUMN}})</countFunction>
-            <maxFunction>MAX({{COLUMN}})</maxFunction>
-            <minFunction>MIN({{COLUMN}})</minFunction>
-        </selectQueryFunctions>
-        <stringSize>254</stringSize>
-        <batchEnable>true</batchEnable>
-        <batchSize>1000</batchSize>
-        <typeMapping>
-            <binaryType>BLOB</binaryType>
-            <booleanType>TINYINT(1)</booleanType>
-            <doubleType>DOUBLE</doubleType>
-            <floatType>FLOAT</floatType>
             <integerType>INTEGER</integerType>
             <longType>BIGINT</longType>
             <stringType>VARCHAR</stringType>

--- a/modules/siddhi-core/src/main/resources/db-aggregation-config.xml
+++ b/modules/siddhi-core/src/main/resources/db-aggregation-config.xml
@@ -45,7 +45,7 @@
             <countFunction>COUNT({{COLUMN}})</countFunction>
             <maxFunction>MAX({{COLUMN}})</maxFunction>
             <minFunction>MIN({{COLUMN}})</minFunction>
-            <timeConversionFunction>UNIX_TIMESTAMP(from_unixtime({{COLUMN}}/1000,"{{DURATION}}"))</timeConversionFunction>
+            <timeConversionFunction>UNIX_TIMESTAMP(from_unixtime({{COLUMN}}/1000,"{{DURATION}}"))*1000</timeConversionFunction>
         </selectQueryFunctions>
         <timeConversionDurationMapping>
             <day>%Y-%m-%d</day>
@@ -120,7 +120,7 @@
             <countFunction>COUNT({{COLUMN}})</countFunction>
             <maxFunction>MAX({{COLUMN}})</maxFunction>
             <minFunction>MIN({{COLUMN}})</minFunction>
-            <timeConversionFunction>DATEDIFF(second , '19700101',DATEADD({{DURATION}} , DATEDIFF({{DURATION}} , 0, DATEADD(ss, {{COLUMN}}/1000, '19700101')), 0))</timeConversionFunction>
+            <timeConversionFunction>DATEDIFF(second , '19700101',DATEADD({{DURATION}} , DATEDIFF({{DURATION}} , 0, DATEADD(ss, {{COLUMN}}/1000, '19700101')), 0))*1000</timeConversionFunction>
         </selectQueryFunctions>
         <timeConversionDurationMapping>
             <day>dd</day>
@@ -156,7 +156,7 @@
             <countFunction>COUNT({{COLUMN}})</countFunction>
             <maxFunction>MAX({{COLUMN}})</maxFunction>
             <minFunction>MIN({{COLUMN}})</minFunction>
-            <timeConversionFunction>select EXTRACT(epoch from date_trunc('{{DURATION}}',  to_timestamp({{COLUMN}}/1000)));
+            <timeConversionFunction>EXTRACT(epoch from date_trunc('{{DURATION}}',  to_timestamp({{COLUMN}}/1000)))*1000;
             </timeConversionFunction>
         </selectQueryFunctions>
         <timeConversionDurationMapping>

--- a/modules/siddhi-core/src/main/resources/db-aggregation-config.xml
+++ b/modules/siddhi-core/src/main/resources/db-aggregation-config.xml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rdbms-table-configuration>
+<!--    <database name="h2">-->
+<!--        <selectQueryTemplate>-->
+<!--            <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}})</recordInsertQuery>-->
+<!--            <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>-->
+<!--            <whereClause>WHERE {{CONDITION}}</whereClause>-->
+<!--            <selectQueryWithInnerSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}} WHERE {{COLUMN}} IN ({{INNER_QUERY}})-->
+<!--            </selectQueryWithInnerSelect>-->
+<!--            <joinClause>SELECT {{SELECTORS}} FROM ({{FROM_CONDITION}}) AS t1 JOIN ({{INNER_QUERY}}) AS t2 ON {{CONDITION}}-->
+<!--            </joinClause>-->
+<!--            <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>-->
+<!--        </selectQueryTemplate>-->
+<!--        <selectQueryFunctions>-->
+<!--            <sumFunction>SUM({{COLUMN}})</sumFunction>-->
+<!--            <countFunction>COUNT({{COLUMN}})</countFunction>-->
+<!--            <maxFunction>MAX({{COLUMN}})</maxFunction>-->
+<!--            <minFunction>MIN({{COLUMN}})</minFunction>-->
+<!--        </selectQueryFunctions>-->
+<!--        <stringSize>254</stringSize>-->
+<!--        <batchEnable>true</batchEnable>-->
+<!--        <batchSize>1000</batchSize>-->
+<!--        <typeMapping>-->
+<!--            <binaryType>BLOB</binaryType>-->
+<!--            <booleanType>TINYINT(1)</booleanType>-->
+<!--            <doubleType>DOUBLE</doubleType>-->
+<!--            <floatType>FLOAT</floatType>-->
+<!--            <integerType>INTEGER</integerType>-->
+<!--            <longType>BIGINT</longType>-->
+<!--            <stringType>VARCHAR</stringType>-->
+<!--        </typeMapping>-->
+<!--    </database>-->
+    <database name="mysql">
+        <selectQueryTemplate>
+            <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}})</recordInsertQuery>
+            <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <whereClause>WHERE {{CONDITION}}</whereClause>
+            <selectQueryWithInnerSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}} WHERE {{COLUMN}} IN ({{INNER_QUERY}})
+            </selectQueryWithInnerSelect>
+            <joinClause>SELECT {{SELECTORS}} FROM ({{FROM_CONDITION}}) AS t1 JOIN ({{INNER_QUERY}}) AS t2 ON {{CONDITION}}</joinClause>
+            <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
+        </selectQueryTemplate>
+        <selectQueryFunctions>
+            <sumFunction>SUM({{COLUMN}})</sumFunction>
+            <countFunction>COUNT({{COLUMN}})</countFunction>
+            <maxFunction>MAX({{COLUMN}})</maxFunction>
+            <minFunction>MIN({{COLUMN}})</minFunction>
+            <timeConversionFunction>UNIX_TIMESTAMP(from_unixtime({{COLUMN}}/1000,"{{DURATION}}"))</timeConversionFunction>
+        </selectQueryFunctions>
+        <timeConversionDurationMapping>
+            <day>%Y-%m-%d</day>
+            <month>%Y-%m-01</month>
+            <year>%Y-01-01</year>
+        </timeConversionDurationMapping>
+        <stringSize>254</stringSize>
+        <batchEnable>true</batchEnable>
+        <batchSize>1000</batchSize>
+        <typeMapping>
+            <binaryType>BLOB</binaryType>
+            <booleanType>TINYINT(1)</booleanType>
+            <doubleType>DOUBLE</doubleType>
+            <floatType>FLOAT</floatType>
+            <integerType>INTEGER</integerType>
+            <longType>BIGINT</longType>
+            <stringType>VARCHAR</stringType>
+        </typeMapping>
+        <collation>latin1_bin</collation>
+    </database>
+    <database name="oracle">
+        <selectQueryTemplate>
+            <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}})</recordInsertQuery>
+            <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <whereClause>WHERE {{CONDITION}}</whereClause>
+            <selectQueryWithInnerSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}} WHERE {{COLUMN}} IN ({{INNER_QUERY}})
+            </selectQueryWithInnerSelect>
+            <joinClause>SELECT {{SELECTORS}} FROM ({{FROM_CONDITION}}) t1 JOIN ({{INNER_QUERY}}) t2 ON {{CONDITION}}</joinClause>
+            <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
+        </selectQueryTemplate>
+        <selectQueryFunctions>
+            <sumFunction>SUM({{COLUMN}})</sumFunction>
+            <countFunction>COUNT({{COLUMN}})</countFunction>
+            <maxFunction>MAX({{COLUMN}})</maxFunction>
+            <minFunction>MIN({{COLUMN}})</minFunction>
+            <timeConversionFunction>(to_date(trunc((to_date('19700101', 'YYYYMMDD') + ( 1 / 24 / 60 / 60 / 1000) *
+                {{COLUMN}}), '{{DURATION}}'), 'YYYY/MM/DD') - to_date('19700101', 'YYYYMMDD')) * 86400000
+            </timeConversionFunction>
+        </selectQueryFunctions>
+        <timeConversionDurationMapping>
+            <day>ddd</day>
+            <month>month</month>
+            <year>year</year>
+        </timeConversionDurationMapping>
+        <stringSize>254</stringSize>
+        <fieldSizeLimit>2000</fieldSizeLimit>
+        <batchEnable>false</batchEnable>
+        <batchSize>1000</batchSize>
+        <typeMapping>
+            <binaryType>BLOB</binaryType>
+            <booleanType>NUMBER(1)</booleanType>
+            <doubleType>NUMBER(19,4)</doubleType>
+            <floatType>NUMBER(19,4)</floatType>
+            <integerType>NUMBER(10)</integerType>
+            <longType>NUMBER(19)</longType>
+            <stringType>VARCHAR</stringType>
+            <bigStringType>CLOB</bigStringType>
+        </typeMapping>
+    </database>
+    <database name="Microsoft SQL Server">
+        <selectQueryTemplate>
+            <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}})</recordInsertQuery>
+            <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <whereClause>WHERE {{CONDITION}}</whereClause>
+            <selectQueryWithInnerSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}} WHERE {{COLUMN}} IN ({{INNER_QUERY}})
+            </selectQueryWithInnerSelect>
+            <joinClause>SELECT {{SELECTORS}} FROM ({{FROM_CONDITION}}) AS t1 JOIN ({{INNER_QUERY}}) AS t2 ON {{CONDITION}}</joinClause>
+            <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
+        </selectQueryTemplate>
+        <selectQueryFunctions>
+            <sumFunction>SUM({{COLUMN}})</sumFunction>
+            <countFunction>COUNT({{COLUMN}})</countFunction>
+            <maxFunction>MAX({{COLUMN}})</maxFunction>
+            <minFunction>MIN({{COLUMN}})</minFunction>
+            <timeConversionFunction>DATEDIFF(second , '19700101',DATEADD({{DURATION}} , DATEDIFF({{DURATION}} , 0, DATEADD(ss, {{COLUMN}}/1000, '19700101')), 0))</timeConversionFunction>
+        </selectQueryFunctions>
+        <timeConversionDurationMapping>
+            <day>dd</day>
+            <month>mm</month>
+            <year>yy</year>
+        </timeConversionDurationMapping>
+        <stringSize>254</stringSize>
+        <batchEnable>true</batchEnable>
+        <batchSize>1000</batchSize>
+        <typeMapping>
+            <binaryType>VARBINARY(maxFunction)</binaryType>
+            <booleanType>BIT</booleanType>
+            <doubleType>FLOAT(32)</doubleType>
+            <floatType>REAL</floatType>
+            <integerType>INTEGER</integerType>
+            <longType>BIGINT</longType>
+            <stringType>VARCHAR</stringType>
+        </typeMapping>
+        <collation>SQL_Latin1_General_CP1_CS_AS</collation>
+    </database>
+    <database name="PostgreSQL">
+        <selectQueryTemplate>
+            <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}})</recordInsertQuery>
+            <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <whereClause>WHERE {{CONDITION}}</whereClause>
+            <selectQueryWithInnerSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}} WHERE {{COLUMN}} IN ({{INNER_QUERY}})
+            </selectQueryWithInnerSelect>
+            <joinClause>SELECT {{SELECTORS}} FROM ({{FROM_CONDITION}}) AS t1 JOIN ({{INNER_QUERY}}) AS t2 ON {{CONDITION}}</joinClause>
+            <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
+        </selectQueryTemplate>
+        <selectQueryFunctions>
+            <sumFunction>SUM({{COLUMN}})</sumFunction>
+            <countFunction>COUNT({{COLUMN}})</countFunction>
+            <maxFunction>MAX({{COLUMN}})</maxFunction>
+            <minFunction>MIN({{COLUMN}})</minFunction>
+            <timeConversionFunction>select EXTRACT(epoch from date_trunc('{{DURATION}}',  to_timestamp({{COLUMN}}/1000)));
+            </timeConversionFunction>
+        </selectQueryFunctions>
+        <timeConversionDurationMapping>
+            <day>day</day>
+            <month>month</month>
+            <year>year</year>
+        </timeConversionDurationMapping>
+        <stringSize>254</stringSize>
+        <batchEnable>true</batchEnable>
+        <batchSize>1000</batchSize>
+        <typeMapping>
+            <binaryType>BYTEA</binaryType>
+            <booleanType>BOOLEAN</booleanType>
+            <doubleType>DOUBLE PRECISION</doubleType>
+            <floatType>REAL</floatType>
+            <integerType>INTEGER</integerType>
+            <longType>BIGINT</longType>
+            <stringType>VARCHAR</stringType>
+        </typeMapping>
+    </database>
+    <database name="DB2.*">
+        <selectQueryTemplate>
+            <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}})</recordInsertQuery>
+            <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <whereClause>WHERE {{CONDITION}}</whereClause>
+            <selectQueryWithInnerSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}} WHERE {{COLUMN}} IN ({{INNER_QUERY}})
+            </selectQueryWithInnerSelect>
+            <joinClause>SELECT {{SELECTORS}} FROM ({{FROM_CONDITION}}) AS t1 JOIN ({{INNER_QUERY}}) AS t2 ON {{CONDITION}}</joinClause>
+            <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
+        </selectQueryTemplate>
+        <selectQueryFunctions>
+            <sumFunction>SUM({{COLUMN}})</sumFunction>
+            <countFunction>COUNT({{COLUMN}})</countFunction>
+            <maxFunction>MAX({{COLUMN}})</maxFunction>
+            <minFunction>MIN({{COLUMN}})</minFunction>
+        </selectQueryFunctions>
+        <keyExplicitNotNull>true</keyExplicitNotNull>
+        <stringSize>254</stringSize>
+        <batchEnable>true</batchEnable>
+        <batchSize>1000</batchSize>
+        <typeMapping>
+            <binaryType>BLOB(64000)</binaryType>
+            <booleanType>SMALLINT</booleanType>
+            <doubleType>DOUBLE</doubleType>
+            <floatType>REAL</floatType>
+            <integerType>INTEGER</integerType>
+            <longType>BIGINT</longType>
+            <stringType>VARCHAR</stringType>
+        </typeMapping>
+    </database>
+    <database name="Apache Derby">
+        <selectQueryTemplate>
+            <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}})</recordInsertQuery>
+            <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <whereClause>WHERE {{CONDITION}}</whereClause>
+            <selectQueryWithInnerSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}} WHERE {{COLUMN}} IN ({{INNER_QUERY}})
+            </selectQueryWithInnerSelect>
+            <joinClause>SELECT {{SELECTORS}} FROM ({{FROM_CONDITION}}) AS t1 JOIN ({{INNER_QUERY}}) AS t2 ON {{CONDITION}}</joinClause>
+            <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
+        </selectQueryTemplate>
+        <selectQueryFunctions>
+            <sumFunction>SUM({{COLUMN}})</sumFunction>
+            <countFunction>COUNT({{COLUMN}})</countFunction>
+            <maxFunction>MAX({{COLUMN}})</maxFunction>
+            <minFunction>MIN({{COLUMN}})</minFunction>
+        </selectQueryFunctions>
+        <stringSize>254</stringSize>
+        <batchEnable>true</batchEnable>
+        <batchSize>1000</batchSize>
+        <typeMapping>
+            <binaryType>BLOB</binaryType>
+            <booleanType>TINYINT(1)</booleanType>
+            <doubleType>DOUBLE</doubleType>
+            <floatType>FLOAT</floatType>
+            <integerType>INTEGER</integerType>
+            <longType>BIGINT</longType>
+            <stringType>VARCHAR</stringType>
+        </typeMapping>
+    </database>
+</rdbms-table-configuration>

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/aggregation/AggregationFilterTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/aggregation/AggregationFilterTestCase.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.siddhi.core.aggregation;
 
 import io.siddhi.core.SiddhiAppRuntime;

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/aggregation/PurgingTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/aggregation/PurgingTestCase.java
@@ -160,7 +160,7 @@ public class PurgingTestCase {
             );
             AssertJUnit.assertTrue("Data Matched",
                     SiddhiTestHelper.isUnsortedEventsMatch(eventsList, expected));
-            Thread.sleep(80000);
+            Thread.sleep(120000);
 
             events = siddhiAppRuntime.query("from stockAggregation within 0L, 1543664151000L per " +
                     "'seconds' select AGG_TIMESTAMP, symbol, totalPrice ");


### PR DESCRIPTION
## Purpose
In the current incremental aggregation implementation, an in-memory map is maintained with the records for each distinct group produced by the group by clause of the aggregation. Due to this, memory usage depends on the number of such distinct groups.

When the number of distinct groups is not finite, memory consumption will not be finite as well.
In order to avoid this, with persisted aggregation, all the incremental aggregation from days and upward will be executed on top of the database so that the in-memory map will be only kept for up to hours aggregation.

## Approach
With Persisted aggregation, the aggregation for higher granularities will be executing on top of the database at the end of each time granularity(Day - at the end of the day, Month - at the end of the month, Year - at the end of the year). 

### Enabling Persisted Aggregation
The persisted aggregation can be enabled by adding the `@persistedAggregation(enable="true")` annotation on top of the aggregation definition[see Aggregation 1 below]. 

Furthermore, in order to execute the aggregation query, the **cud** function which is there in siddhi-store-rdbms is used. So in order to enable the "cud" operations, please add the following configuration on the deployment.yaml file

```
siddhi:
  extensions:
    -
      extension:
        name: cud
        namespace: rdbms
        properties:
          perform.CUD.operations: true
```
In order to use persisted aggregation, A datasource needs to configured through deployment.yaml file and it should be pointed out in @store annotation of the aggregation definition. 
Furthermore when using persisted aggregation with MySQL, please provide the aggregation processing timezone in JDBC URL since by default MySQL database will use server timezone for some time-related conversions which are there in an aggregation query. 
```
jdbc:mysql://localhost:3306/TEST_DB?useSSL=false&tz=useLegacyDatetimeCode=false&serverTimezone=UTC
```
For an example please refer to the following query which will be executed on the database to update the table for below sample Aggregation 1,
#### Aggregation 1
```
@persistedAggregation(enable="true")
define aggregation ResponseStreamAggregation
from processedResponseStream
select api, version, apiPublisher, applicationName, protocol, consumerKey, userId, context, resourcePath, responseCode, 
    avg(serviceTime) as avg_service_time, avg(backendTime) as avg_backend_time, sum(responseTime) as total_response_count, time1, epoch, eventTime
group by api, version, apiPublisher, applicationName, protocol, consumerKey, userId, context, resourcePath, responseCode, time1, epoch
aggregate by eventTime every min;
```
#### Sample query 
```
INSERT INTO API_RESPONSE_SUMMARY_UTC_DAYS (AGG_TIMESTAMP, SHARD_ID, AGG_EVENT_TIMESTAMP, api, version, apiPublisher,
                                             applicationName, protocol, consumerKey, userId, context, resourcePath,
                                             responseCode, eventTime, AGG_LAST_EVENT_TIMESTAMP, AGG_COUNT,
                                             AGG_SUM_serviceTime, AGG_SUM_backendTime)
SELECT ?                           AS AGG_TIMESTAMP,
       t1.SHARD_ID                 AS SHARD_ID,
       t1.AGG_EVENT_TIMESTAMP      AS AGG_EVENT_TIMESTAMP,
       t1.api                      AS api,
       t1.version                  AS version,
       t1.apiPublisher             AS apiPublisher,
       t1.applicationName          AS applicationName,
       t1.protocol                 AS protocol,
       t1.consumerKey              AS consumerKey,
       t1.userId                   AS userId,
       t1.context                  AS context,
       t1.resourcePath             AS resourcePath,
       t1.responseCode             AS responseCode,
       t2.eventTime                AS eventTime,
       t2.AGG_LAST_EVENT_TIMESTAMP AS AGG_LAST_EVENT_TIMESTAMP,
       t1.AGG_COUNT                AS AGG_COUNT,
       t1.AGG_SUM_serviceTime      AS AGG_SUM_serviceTime,
       t1.AGG_SUM_backendTime      AS AGG_SUM_backendTime
FROM (SELECT SHARD_ID,
             (to_date(trunc((to_date('19700101', 'YYYYMMDD') + (1 / 24 / 60 / 60 / 1000) *
                                                               AGG_EVENT_TIMESTAMP), 'day'), 'YYYY/MM/DD') -
              to_date('19700101', 'YYYYMMDD')) * 86400000
                                      AS AGG_EVENT_TIMESTAMP,
             api,
             version,
             apiPublisher,
             applicationName,
             protocol,
             consumerKey,
             userId,
             context,
             resourcePath,
             responseCode,
             SUM(AGG_COUNT)           AS AGG_COUNT,
             SUM(AGG_SUM_serviceTime) AS AGG_SUM_serviceTime,
             SUM(AGG_SUM_backendTime) AS AGG_SUM_backendTime
      FROM API_RESPONSE_SUMMARY_UTC_HOURS
      WHERE (AGG_TIMESTAMP >= ? AND AGG_TIMESTAMP < ?)
        AND SHARD_ID = 'wso2-si'
      GROUP BY SHARD_ID, api, version, apiPublisher, applicationName, protocol, consumerKey, userId, context,
               resourcePath, responseCode,
               (to_date(trunc((to_date('19700101', 'YYYYMMDD') + (1 / 24 / 60 / 60 / 1000) *
                                                                 AGG_EVENT_TIMESTAMP), 'day'), 'YYYY/MM/DD') -
                to_date('19700101', 'YYYYMMDD')) * 86400000
     ) t1
         JOIN (SELECT (to_date(trunc((to_date('19700101', 'YYYYMMDD') + (1 / 24 / 60 / 60 / 1000) *
                                                                        AGG_EVENT_TIMESTAMP), 'day'), 'YYYY/MM/DD') -
                       to_date('19700101', 'YYYYMMDD')) * 86400000
                          AS AGG_EVENT_TIMESTAMP,
                      api,
                      version,
                      apiPublisher,
                      applicationName,
                      protocol,
                      consumerKey,
                      userId,
                      context,
                      resourcePath,
                      responseCode,
                      eventTime,
                      AGG_LAST_EVENT_TIMESTAMP
               FROM API_RESPONSE_SUMMARY_UTC_HOURS
               WHERE AGG_LAST_EVENT_TIMESTAMP IN (SELECT MAX(AGG_LAST_EVENT_TIMESTAMP)
                                                  FROM API_RESPONSE_SUMMARY_UTC_HOURS
                                                  WHERE (AGG_TIMESTAMP >= ? AND AGG_TIMESTAMP < ?)
                                                    AND SHARD_ID = 'wso2-si'
                                                  GROUP BY SHARD_ID, api, version, apiPublisher, applicationName,
                                                           protocol, consumerKey, userId, context, resourcePath,
                                                           responseCode,
                                                           (to_date(trunc((to_date('19700101', 'YYYYMMDD') +
                                                                           (1 / 24 / 60 / 60 / 1000) *
                                                                           AGG_EVENT_TIMESTAMP), 'day'),
                                                                    'YYYY/MM/DD') - to_date('19700101', 'YYYYMMDD')) *
                                                           86400000
               )
) t2 ON t1.api = t2.api AND t1.version = t2.version AND t1.apiPublisher = t2.apiPublisher AND
        t1.applicationName = t2.applicationName AND t1.protocol = t2.protocol AND t1.consumerKey = t2.consumerKey AND
        t1.userId = t2.userId AND t1.context = t2.context AND t1.resourcePath = t2.resourcePath AND
        t1.responseCode = t2.responseCode AND t1.AGG_EVENT_TIMESTAMP = t2.AGG_EVENT_TIMESTAMP
```



## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
 Java version: 1.8.0_221, vendor: Oracle Corporation
DB types - 

- Oracle

- MySQL

- SqlServer

- PostgreSQL
 
## Related PR's
https://github.com/wso2/carbon-analytics/pull/1910