### PR TITLE
Fix high cpu consumption

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/error/handler/store/ErrorStore.java
@@ -18,7 +18,7 @@
 
 package io.siddhi.core.util.error.handler.store;
 
-import com.lmax.disruptor.BusySpinWaitStrategy;
+import com.lmax.disruptor.BlockingWaitStrategy;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.InsufficientCapacityException;
 import com.lmax.disruptor.RingBuffer;
@@ -56,7 +56,7 @@ public abstract class ErrorStore {
     public ErrorStore() {
         final ThreadFactory threadFactory = DaemonThreadFactory.INSTANCE;
         disruptor = new Disruptor<>(PublishableErrorEntry.EVENT_FACTORY, bufferSize, threadFactory, ProducerType.SINGLE,
-                new BusySpinWaitStrategy());
+                new BlockingWaitStrategy());
         disruptor.handleEventsWith(getEventHandler());
         ringBuffer = disruptor.start();
     }


### PR DESCRIPTION
## Purpose
To fix high CPU consumption when siddhi error store is configured

## Goals
Avoid high cpu consumption

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
