### PR TITLE
Fix extension loading issue in Windows environment

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/InputEventHandler.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/stream/input/source/InputEventHandler.java
@@ -69,9 +69,7 @@ public class InputEventHandler {
                 latencyTracker.markOut();
             }
             Object[] transportProperties = trpProperties.get();
-            trpProperties.remove();
             String[] transportSyncProperties = trpSyncProperties.get();
-            trpSyncProperties.remove();
             if (event.getTimestamp() == -1) {
                 long currentTimestamp = timestampGenerator.currentTime();
                 event.setTimestamp(currentTimestamp);
@@ -87,9 +85,6 @@ public class InputEventHandler {
             LOG.error(ExceptionUtil.getMessageWithContext(e, siddhiAppContext) +
                     " Error in applying transport property mapping for '" + sourceType
                     + "' source at '" + inputHandler.getStreamId() + "' stream.", e);
-        } finally {
-            trpProperties.remove();
-            trpSyncProperties.remove();
         }
     }
 

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/AbstractExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/AbstractExtensionHolder.java
@@ -41,14 +41,11 @@ public abstract class AbstractExtensionHolder {
                     if (extensionMap.containsKey(extensionKey)) {
                         log.error("Extension class " + extension.getName() + " not loaded, as there is already an" +
                                 " matching extension '" + extensionKey + "' implemented as " + extensionMap
-                                .get
-                                        (extensionKey).getName());
+                                .get(extensionKey).getName());
                     } else {
                         extensionMap.put(extensionKey, extension);
                     }
-
                 }
-
             }
         }
     }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/AttributeAggregatorExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/AttributeAggregatorExtensionHolder.java
@@ -36,10 +36,14 @@ public class AttributeAggregatorExtensionHolder extends AbstractExtensionHolder 
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap = siddhiAppContext.getSiddhiContext
                 ().getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new AttributeAggregatorExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new AttributeAggregatorExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (AttributeAggregatorExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/DistributionStrategyExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/DistributionStrategyExtensionHolder.java
@@ -37,10 +37,14 @@ public class DistributionStrategyExtensionHolder extends AbstractExtensionHolder
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap
                 = siddhiAppContext.getSiddhiContext().getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new DistributionStrategyExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new DistributionStrategyExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (DistributionStrategyExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/FunctionExecutorExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/FunctionExecutorExtensionHolder.java
@@ -36,10 +36,14 @@ public class FunctionExecutorExtensionHolder extends AbstractExtensionHolder {
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap = siddhiAppContext.getSiddhiContext
                 ().getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new FunctionExecutorExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new FunctionExecutorExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (FunctionExecutorExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/IncrementalAttributeAggregatorExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/IncrementalAttributeAggregatorExtensionHolder.java
@@ -37,10 +37,14 @@ public class IncrementalAttributeAggregatorExtensionHolder extends AbstractExten
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap = siddhiAppContext.getSiddhiContext()
                 .getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new IncrementalAttributeAggregatorExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new IncrementalAttributeAggregatorExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (IncrementalAttributeAggregatorExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/ScriptExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/ScriptExtensionHolder.java
@@ -37,10 +37,14 @@ public class ScriptExtensionHolder extends AbstractExtensionHolder {
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap =
                 siddhiAppContext.getSiddhiContext().getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new ScriptExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new ScriptExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (ScriptExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/SinkExecutorExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/SinkExecutorExtensionHolder.java
@@ -36,10 +36,14 @@ public class SinkExecutorExtensionHolder extends AbstractExtensionHolder {
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap = siddhiAppContext.getSiddhiContext
                 ().getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new SinkExecutorExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new SinkExecutorExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (SinkExecutorExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/SinkMapperExecutorExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/SinkMapperExecutorExtensionHolder.java
@@ -37,10 +37,14 @@ public class SinkMapperExecutorExtensionHolder extends AbstractExtensionHolder {
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap = siddhiAppContext.getSiddhiContext()
                 .getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new SinkMapperExecutorExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new SinkMapperExecutorExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (SinkMapperExecutorExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/SourceExecutorExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/SourceExecutorExtensionHolder.java
@@ -36,10 +36,14 @@ public class SourceExecutorExtensionHolder extends AbstractExtensionHolder {
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap = siddhiAppContext.getSiddhiContext
                 ().getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new SourceExecutorExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new SourceExecutorExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (SourceExecutorExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/SourceMapperExecutorExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/SourceMapperExecutorExtensionHolder.java
@@ -37,10 +37,14 @@ public class SourceMapperExecutorExtensionHolder extends AbstractExtensionHolder
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap = siddhiAppContext.getSiddhiContext
                 ().getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new SourceMapperExecutorExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new SourceMapperExecutorExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (SourceMapperExecutorExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/StreamFunctionProcessorExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/StreamFunctionProcessorExtensionHolder.java
@@ -36,10 +36,14 @@ public class StreamFunctionProcessorExtensionHolder extends AbstractExtensionHol
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap = siddhiAppContext.getSiddhiContext
                 ().getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new StreamFunctionProcessorExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new StreamFunctionProcessorExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (StreamFunctionProcessorExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/StreamProcessorExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/StreamProcessorExtensionHolder.java
@@ -36,10 +36,14 @@ public class StreamProcessorExtensionHolder extends AbstractExtensionHolder {
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap = siddhiAppContext.getSiddhiContext
                 ().getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new StreamProcessorExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new StreamProcessorExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (StreamProcessorExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/TableExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/TableExtensionHolder.java
@@ -37,10 +37,14 @@ public class TableExtensionHolder extends AbstractExtensionHolder {
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap = siddhiAppContext.getSiddhiContext
                 ().getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new TableExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new TableExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (TableExtensionHolder) extensionHolderMap.get(clazz);
     }
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/WindowProcessorExtensionHolder.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/extension/holder/WindowProcessorExtensionHolder.java
@@ -36,10 +36,14 @@ public class WindowProcessorExtensionHolder extends AbstractExtensionHolder {
         ConcurrentHashMap<Class, AbstractExtensionHolder> extensionHolderMap = siddhiAppContext.getSiddhiContext
                 ().getExtensionHolderMap();
         AbstractExtensionHolder abstractExtensionHolder = extensionHolderMap.get(clazz);
-        if (abstractExtensionHolder == null) {
+        if (abstractExtensionHolder != null && siddhiAppContext.getSiddhiContext().getSiddhiExtensions().size() !=
+                abstractExtensionHolder.extensionMap.size()) {
+            extensionHolderMap.remove(clazz);
             abstractExtensionHolder = new WindowProcessorExtensionHolder(siddhiAppContext);
-            extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
+        } else if (abstractExtensionHolder == null) {
+            abstractExtensionHolder = new WindowProcessorExtensionHolder(siddhiAppContext);
         }
+        extensionHolderMap.putIfAbsent(clazz, abstractExtensionHolder);
         return (WindowProcessorExtensionHolder) extensionHolderMap.get(clazz);
     }
 }


### PR DESCRIPTION
## Purpose
- Resolves https://github.com/siddhi-io/siddhi/issues/1719. This fix is provided by @dnwick 

- Resolves https://github.com/siddhi-io/siddhi-map-json/issues/100
  
The trpProperties is set in the SourceMapper but it is removed by both SourceMapper and InputEventHandler.
For each event SourceMapper gets, it sets the trpProperties and hands over the event to InputEventHandler. After that removes the trpProperties.
For each event InputEventHandler gets, it removes the trpProperties too (it is unclear why it is doing this duplicate work).
Problem occurs when a batch of events comes to SourceMapper and it invokes the InputEventHandler multiple times (once for each event in the batch). Since InputEventHandler removes the trpProperties each time it gets an event; but the SourceMapper only sets it once for the whole batch, the 2nd event in the batch gets null for the trpProperties. This is the rootcause of this issue.

In this fix, we assume that only the SourceMapper submits events to the InputEventHandler. So setting/removal of trpProperties is handled solely by the SourceMapper.

## Release note
Fixes https://github.com/siddhi-io/siddhi/issues/1719
Fixes https://github.com/siddhi-io/siddhi-map-json/issues/100

## Automation tests
 - Unit tests for https://github.com/siddhi-io/siddhi-map-json/issues/100 is a TODO
 - https://github.com/siddhi-io/siddhi/issues/1719 cannot be automated as it is a rare intermittent issue which occurs only in Windows environments.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
