### PR TITLE
Improve persisted aggregations by introducing a queue implementation

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/CudStreamProcessorQueueManager.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/CudStreamProcessorQueueManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/CudStreamProcessorQueueManager.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/CudStreamProcessorQueueManager.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.aggregation.persistedaggregation;
+
+import io.siddhi.core.event.ComplexEventChunk;
+import org.apache.log4j.Logger;
+
+import java.sql.SQLException;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Implements functions to manage the queue
+ **/
+public class CudStreamProcessorQueueManager implements Runnable {
+    private static final Logger log = Logger.getLogger(CudStreamProcessorQueueManager.class);
+    private volatile boolean run = true;
+    private LinkedBlockingQueue<QueuedCudStreamProcessor> cudStreamProcessorQueue;
+
+    public LinkedBlockingQueue<QueuedCudStreamProcessor> initializeAndGetCudStreamProcessorQueue() {
+        cudStreamProcessorQueue = new LinkedBlockingQueue<QueuedCudStreamProcessor>();
+        return cudStreamProcessorQueue;
+    }
+
+    public LinkedBlockingQueue<QueuedCudStreamProcessor> getCudStreamProcessorQueue() {
+        return this.cudStreamProcessorQueue;
+    }
+
+    @Override
+    public void run() {
+        while (run) {
+            QueuedCudStreamProcessor queuedCudStreamProcessor = null;
+            try {
+                queuedCudStreamProcessor = this.cudStreamProcessorQueue.take();
+            } catch (InterruptedException e) {
+                log.warn("Thread interrupted. Error when trying to retrieve queued values." + e.getMessage());
+            }
+            if (null != queuedCudStreamProcessor) {
+                int i = 0;
+                while (true) {
+                    i++;
+                    try {
+                        ComplexEventChunk complexEventChunk = new ComplexEventChunk();
+                        complexEventChunk.add(queuedCudStreamProcessor.getStreamEvent());
+                        queuedCudStreamProcessor.getCudStreamProcessor().
+                                process(complexEventChunk);
+                        complexEventChunk.clear();
+                        break;
+                    } catch (Exception e) {
+                        if (e.getCause() instanceof SQLException) {
+                            if (e.getCause().getLocalizedMessage().contains("try restarting transaction") && i < 3) {
+                                log.error("Error occurred while executing the aggregation for data between " +
+                                        queuedCudStreamProcessor.getStartTimeOfNewAggregates() + " - " +
+                                        queuedCudStreamProcessor.getEmittedTime() + " for duration " +
+                                        queuedCudStreamProcessor.getDuration() +
+                                        " Retrying the transaction attempt " + (i - 1), e);
+                                try {
+                                    Thread.sleep(3000);
+                                } catch (InterruptedException interruptedException) {
+                                    log.error("Thread sleep interrupted while waiting to re-execute the " +
+                                            "aggregation query for duration " +
+                                            queuedCudStreamProcessor.getDuration(), interruptedException);
+                                }
+                                continue;
+                            }
+                            log.error("Error occurred while executing the aggregation for data between "
+                                    + queuedCudStreamProcessor.getStartTimeOfNewAggregates() + " - " +
+                                    queuedCudStreamProcessor.getEmittedTime() + " for duration " +
+                                    queuedCudStreamProcessor.getDuration() +
+                                    ". Attempted re-executing the query for 9 seconds. " +
+                                    "This Should be investigated since this will lead to a data mismatch\n", e);
+                        } else {
+                            log.error("Error occurred while executing the aggregation for data between "
+                                    + queuedCudStreamProcessor.getStartTimeOfNewAggregates() + " - " +
+                                    queuedCudStreamProcessor.getEmittedTime() + " for duration \n" +
+                                    queuedCudStreamProcessor.getDuration(), e);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/QueuedCudStreamProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/QueuedCudStreamProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/QueuedCudStreamProcessor.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/aggregation/persistedaggregation/QueuedCudStreamProcessor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.aggregation.persistedaggregation;
+
+import io.siddhi.core.event.stream.StreamEvent;
+import io.siddhi.core.query.processor.Processor;
+import io.siddhi.query.api.aggregation.TimePeriod;
+
+/**
+ * Holds the attributes to be stored in the queue
+ **/
+public class QueuedCudStreamProcessor {
+    private Processor cudStreamProcessor;
+    private StreamEvent streamEvent;
+    private long startTimeOfNewAggregates;
+    private long emittedTime;
+    private String timeZone;
+    private TimePeriod.Duration duration;
+
+    public QueuedCudStreamProcessor(Processor cudStreamProcessor, StreamEvent streamEvent,
+                                    long startTimeOfNewAggregates, long emittedTime, String timeZone,
+                                    TimePeriod.Duration duration) {
+        this.cudStreamProcessor = cudStreamProcessor;
+        this.streamEvent = streamEvent;
+        this.startTimeOfNewAggregates = startTimeOfNewAggregates;
+        this.emittedTime = emittedTime;
+        this.timeZone = timeZone;
+        this.duration = duration;
+    }
+
+    public Processor getCudStreamProcessor() {
+
+        return cudStreamProcessor;
+    }
+
+    public void setCudStreamProcessor(Processor cudStreamProcessor) {
+
+        this.cudStreamProcessor = cudStreamProcessor;
+    }
+
+    public long getStartTimeOfNewAggregates() {
+
+        return startTimeOfNewAggregates;
+    }
+
+    public void setStartTimeOfNewAggregates(long startTimeOfNewAggregates) {
+
+        this.startTimeOfNewAggregates = startTimeOfNewAggregates;
+    }
+
+    public long getEmittedTime() {
+
+        return emittedTime;
+    }
+
+    public void setEmittedTime(long emittedTime) {
+
+        this.emittedTime = emittedTime;
+    }
+
+    public String getTimeZone() {
+
+        return timeZone;
+    }
+
+    public void setTimeZone(String timeZone) {
+
+        this.timeZone = timeZone;
+    }
+
+    public TimePeriod.Duration getDuration() {
+
+        return duration;
+    }
+
+    public void setDuration(TimePeriod.Duration duration) {
+
+        this.duration = duration;
+    }
+
+    public StreamEvent getStreamEvent() {
+
+        return streamEvent;
+    }
+
+    public void setStreamEvent(StreamEvent streamEvent) {
+
+        this.streamEvent = streamEvent;
+    }
+}

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/parser/AggregationParser.java
@@ -24,7 +24,9 @@ import io.siddhi.core.aggregation.IncrementalAggregationProcessor;
 import io.siddhi.core.aggregation.IncrementalDataPurger;
 import io.siddhi.core.aggregation.IncrementalExecutor;
 import io.siddhi.core.aggregation.IncrementalExecutorsInitialiser;
+import io.siddhi.core.aggregation.persistedaggregation.CudStreamProcessorQueueManager;
 import io.siddhi.core.aggregation.persistedaggregation.PersistedIncrementalExecutor;
+import io.siddhi.core.aggregation.persistedaggregation.QueuedCudStreamProcessor;
 import io.siddhi.core.aggregation.persistedaggregation.config.DBAggregationQueryConfigurationEntry;
 import io.siddhi.core.aggregation.persistedaggregation.config.DBAggregationQueryUtil;
 import io.siddhi.core.aggregation.persistedaggregation.config.DBAggregationSelectFunctionTemplate;
@@ -103,6 +105,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.TimeZone;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
@@ -556,6 +559,15 @@ public class AggregationParser {
             cudProcessors = initAggregateQueryExecutor(incrementalDurations, processExpressionExecutorsMap,
                     incomingOutputStreamDefinition, isDistributed, shardId, isProcessingOnExternalTime,
                     siddhiQueryContext, aggregationDefinition, configManager, aggregationTables, groupByVariableList);
+
+            CudStreamProcessorQueueManager queueManager = new CudStreamProcessorQueueManager();
+
+            //initialize cud stream processor queue
+            LinkedBlockingQueue<QueuedCudStreamProcessor> cudStreamProcessorQueue =
+                    queueManager.initializeAndGetCudStreamProcessorQueue();
+
+            siddhiQueryContext.getSiddhiAppContext().getExecutorService().execute(queueManager);
+
             for (int i = incrementalDurations.size() - 1; i >= 0; i--) {
                 // Base incremental expression executors created using new meta
 
@@ -579,7 +591,7 @@ public class AggregationParser {
                     incrementalExecutor = new PersistedIncrementalExecutor(aggregatorName, duration,
                             processExpressionExecutorsMap.get(duration),
                             child, siddhiQueryContext, generateCUDMetaStreamEvent(isProcessingOnExternalTime), timeZone,
-                            cudProcessors.get(duration));
+                            cudProcessors.get(duration), cudStreamProcessorQueue);
                 }
                 incrementalExecutorMap.put(duration, incrementalExecutor);
                 root = incrementalExecutor;
@@ -1255,7 +1267,6 @@ public class AggregationParser {
                             .equals(AGG_START_TIMESTAMP_COL)) {
                         outerSelectColumnJoiner.add(" ? " + SQL_AS + variableExpressionExecutor.getAttribute().getName());
                     } else if (!variableExpressionExecutor.getAttribute().getName().equals(AGG_EXTERNAL_TIMESTAMP_COL)) {
-                        subSelectT2ColumnJoiner.add(variableExpressionExecutor.getAttribute().getName());
                         if (groupByColumnNames.contains(variableExpressionExecutor.getAttribute().getName())) {
                             subSelectT2ColumnJoiner.add(INNER_SELECT_QUERY_REF_T3 + "." +
                                     variableExpressionExecutor.getAttribute().getName() + SQL_AS +


### PR DESCRIPTION
## Purpose
Allow persisted aggregations to run in a separate thread to stop the main thread getting hanged when the processing takes time

## Goals
Improve logic

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
