### PR TITLE
Add runtime warnings for the deprecated extensions used in Siddhi Apps

### DIFF
--- a/modules/siddhi-annotations/src/main/java/io/siddhi/annotation/Extension.java
+++ b/modules/siddhi-annotations/src/main/java/io/siddhi/annotation/Extension.java
@@ -62,6 +62,8 @@ public @interface Extension {
 
     boolean deprecated() default false;
 
+    String deprecationNotice() default "";
+
     Parameter[] parameters() default {};
 
     ParameterOverload[] parameterOverloads() default {};

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/SiddhiAppRuntime.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/SiddhiAppRuntime.java
@@ -193,4 +193,10 @@ public interface SiddhiAppRuntime {
      */
     void enablePlayBack(boolean playBackEnabled, Long idleTime, Long incrementInMilliseconds);
 
+    /**
+     * Method to get Siddhi App runtime warnings.
+     *
+     * @return list of recorded runtime warnings.
+     */
+    Set<String> getWarnings();
 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/SiddhiAppRuntimeImpl.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/SiddhiAppRuntimeImpl.java
@@ -19,6 +19,7 @@
 package io.siddhi.core;
 
 import com.lmax.disruptor.ExceptionHandler;
+import io.siddhi.annotation.Extension;
 import io.siddhi.core.aggregation.AggregationRuntime;
 import io.siddhi.core.config.SiddhiAppContext;
 import io.siddhi.core.debugger.SiddhiDebugger;
@@ -930,7 +931,7 @@ public class SiddhiAppRuntimeImpl implements SiddhiAppRuntime {
     }
 
     private void collectDeprecateWarnings() {
-        Set<String> deprecatedExtensions = siddhiAppContext.getSiddhiContext().getDeprecatedSiddhiExtensions().keySet();
+        Map<String, Class> deprecatedExtensions = siddhiAppContext.getSiddhiContext().getDeprecatedSiddhiExtensions();
         List<AbstractDefinition> extensionsInUse = new ArrayList<>();
         extensionsInUse.addAll(streamDefinitionMap.values());
         extensionsInUse.addAll(tableDefinitionMap.values());
@@ -948,8 +949,12 @@ public class SiddhiAppRuntimeImpl implements SiddhiAppRuntime {
                 if (annotation.getName().equalsIgnoreCase(SiddhiConstants.ANNOTATION_STORE)) {
                     type = "store:" + type;
                 }
-                if (deprecatedExtensions.contains(type)) {
-                    String warning = type + " is being deprecated.";
+                if (deprecatedExtensions.containsKey(type)) {
+                    Class ext = deprecatedExtensions.get(type);
+                    Extension extAnnotation = (Extension) ext.getAnnotation(Extension.class);
+                    String warning = extAnnotation.deprecationNotice().isEmpty()
+                            ? type + " is being deprecated."
+                            : extAnnotation.deprecationNotice();
                     warnings.add(warning);
                     log.warn(warning);
                 }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/SiddhiAppRuntimeImpl.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/SiddhiAppRuntimeImpl.java
@@ -949,7 +949,7 @@ public class SiddhiAppRuntimeImpl implements SiddhiAppRuntime {
                 if (annotation.getName().equalsIgnoreCase(SiddhiConstants.ANNOTATION_STORE)) {
                     type = "store:" + type;
                 }
-                if (deprecatedExtensions.containsKey(type)) {
+                if (type != null && deprecatedExtensions.containsKey(type)) {
                     Class ext = deprecatedExtensions.get(type);
                     Extension extAnnotation = (Extension) ext.getAnnotation(Extension.class);
                     String warning = extAnnotation.deprecationNotice().isEmpty()

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/config/SiddhiContext.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/config/SiddhiContext.java
@@ -48,6 +48,7 @@ public class SiddhiContext {
 
     private ExceptionHandler<Object> defaultDisrupterExceptionHandler;
     private Map<String, Class> siddhiExtensions = new HashMap<>();
+    private Map<String, Class> deprecatedSiddhiExtensions = new HashMap<>();
     private PersistenceStore persistenceStore = null;
     private IncrementalPersistenceStore incrementalPersistenceStore = null;
     private ErrorStore errorStore = null;
@@ -62,7 +63,7 @@ public class SiddhiContext {
     private Map<String, Object> attributes;
 
     public SiddhiContext() {
-        SiddhiExtensionLoader.loadSiddhiExtensions(siddhiExtensions, extensionHolderMap);
+        SiddhiExtensionLoader.loadSiddhiExtensions(siddhiExtensions, extensionHolderMap, deprecatedSiddhiExtensions);
         siddhiDataSources = new ConcurrentHashMap<String, DataSource>();
         statisticsConfiguration = new StatisticsConfiguration(new SiddhiMetricsFactory());
         configManager = new InMemoryConfigManager();
@@ -152,6 +153,10 @@ public class SiddhiContext {
 
     public ConcurrentHashMap<Class, AbstractExtensionHolder> getExtensionHolderMap() {
         return extensionHolderMap;
+    }
+
+    public Map<String, Class> getDeprecatedSiddhiExtensions() {
+        return deprecatedSiddhiExtensions;
     }
 
     public ExceptionHandler<Object> getDefaultDisrupterExceptionHandler() {

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/managment/WarningTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/managment/WarningTestCase.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.core.managment;
+
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.util.EventPrinter;
+import org.apache.log4j.Logger;
+import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class WarningTestCase {
+    private static final Logger log = Logger.getLogger(WarningTestCase.class);
+
+    @BeforeMethod
+    public void init() {
+        // do nothing.
+    }
+
+    @Test
+    public void warningTest() throws InterruptedException {
+        log.info("warningTest");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "define stream StockStream (symbol string, price float, volume long); " +
+                "@Store(type=\"testStoreContainingInMemoryTable\")\n" +
+                "define table StockTable (symbol string, volume long); ";
+
+        String query1 = "" +
+                "@info(name = 'query1') " +
+                "from StockStream\n" +
+                "select symbol, volume\n" +
+                "insert into StockTable ;";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query1);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        stockStream.send(new Object[]{"WSO2", 55.6f, 100L});
+        stockStream.send(new Object[]{"IBM", 75.6f, 100L});
+        Thread.sleep(1000);
+
+        Event[] events = siddhiAppRuntime.query("" +
+                "from StockTable ");
+        EventPrinter.print(events);
+        AssertJUnit.assertEquals(2, events.length);
+        AssertJUnit.assertEquals(1, siddhiAppRuntime.getWarnings().size());
+        AssertJUnit.assertTrue(siddhiAppRuntime.getWarnings()
+                .contains("store:testStoreContainingInMemoryTable is being deprecated."));
+        siddhiAppRuntime.shutdown();
+    }
+}

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/managment/WarningTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/managment/WarningTestCase.java
@@ -63,7 +63,7 @@ public class WarningTestCase {
         AssertJUnit.assertEquals(2, events.length);
         AssertJUnit.assertEquals(1, siddhiAppRuntime.getWarnings().size());
         AssertJUnit.assertTrue(siddhiAppRuntime.getWarnings()
-                .contains("store:testStoreContainingInMemoryTable is being deprecated."));
+                .contains("store:testStoreContainingInMemoryTable is being deprecated for testing purposes."));
         siddhiAppRuntime.shutdown();
     }
 }

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/util/TestStoreContainingInMemoryTable.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/util/TestStoreContainingInMemoryTable.java
@@ -69,6 +69,7 @@ import static io.siddhi.core.util.OnDemandQueryRuntimeUtil.executeSelector;
  */
 @Extension(
         name = "testStoreContainingInMemoryTable",
+        deprecated = true,
         namespace = "store",
         description = "Using this implementation a testing for store extension can be done.",
         examples = {

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/util/TestStoreContainingInMemoryTable.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/util/TestStoreContainingInMemoryTable.java
@@ -70,6 +70,7 @@ import static io.siddhi.core.util.OnDemandQueryRuntimeUtil.executeSelector;
 @Extension(
         name = "testStoreContainingInMemoryTable",
         deprecated = true,
+        deprecationNotice = "store:testStoreContainingInMemoryTable is being deprecated for testing purposes.",
         namespace = "store",
         description = "Using this implementation a testing for store extension can be done.",
         examples = {

--- a/modules/siddhi-query-compiler/pom.xml
+++ b/modules/siddhi-query-compiler/pom.xml
@@ -147,6 +147,6 @@
     </build>
 
     <properties>
-        <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
+        <mavan.findbugsplugin.exclude.file>../../findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
$title. Currently `deprecated = true` is only used with doc gen. With this PR it will also give a runtime warning for such extensions.

## Samples
```
@Extension(
        name = "xxxxx",
        deprecated = true,
        namespace = "xxxxx",
        description = "xxxxx",
        examples = {
                @Example(
                        xxxxx
                )
        }
)
```

## Goals
n/a

## Approach
n/a

## Release note
- deprecated extensions will give a warning at the runtime.
 
## Documentation
n/a

## Automation tests
 - Unit tests added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Related PRs
n/a

## Test environment
n/a
