### PR TITLE
Add missing Siddhi keywords under 'keyword' section

### DIFF
--- a/modules/siddhi-query-compiler/src/main/antlr4/io/siddhi/query/compiler/SiddhiQL.g4
+++ b/modules/siddhi-query-compiler/src/main/antlr4/io/siddhi/query/compiler/SiddhiQL.g4
@@ -660,6 +660,15 @@ keyword
     | DOUBLE
     | BOOL
     | OBJECT
+    | FUNCTION
+    | TRIGGER
+    | OFFSET
+    | SET
+    | AT
+    | IN
+    | AGGREGATION
+    | AGGREGATE
+    | PER
     ;
 
 time_value


### PR DESCRIPTION
## Purpose
Add the following keywords under the `keyword` section of `SiddhiQL.g4` file.
```
FUNCTION
TRIGGER
OFFSET
SET
AT
IN
AGGREGATION
AGGREGATE
PER
```

## Goal
Support using the above mentioned keywords as stream/table attributes. Resolves https://github.com/siddhi-io/siddhi/issues/1742