### PR TITLE
Fix failing test cases in `CacheCornerCasesTest` and `CacheExpiryAndReloadTestCase`

### DIFF
--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/cache/CacheCornerCasesTest.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/cache/CacheCornerCasesTest.java
@@ -135,10 +135,8 @@ public class CacheCornerCasesTest {
         List<String> logMessages = new ArrayList<>();
         for (LoggingEvent logEvent : log) {
             String message = String.valueOf(logEvent.getMessage());
-            if (message.contains(": ")) {
-                message = message.split(": ")[1];
-            } else if (message.contains(":")) {
-                message = message.split(":")[1];
+            if (message.contains(":")) {
+                message = message.split(":")[1].trim();
             }
             logMessages.add(message);
         }

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/cache/CacheCornerCasesTest.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/cache/CacheCornerCasesTest.java
@@ -135,8 +135,10 @@ public class CacheCornerCasesTest {
         List<String> logMessages = new ArrayList<>();
         for (LoggingEvent logEvent : log) {
             String message = String.valueOf(logEvent.getMessage());
-            if (message.contains(":")) {
+            if (message.contains(": ")) {
                 message = message.split(": ")[1];
+            } else if (message.contains(":")) {
+                message = message.split(":")[1];
             }
             logMessages.add(message);
         }

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/cache/CacheExpiryAndReloadTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/cache/CacheExpiryAndReloadTestCase.java
@@ -66,8 +66,10 @@ public class CacheExpiryAndReloadTestCase {
         List<String> logMessages = new ArrayList<>();
         for (LoggingEvent logEvent : log) {
             String message = String.valueOf(logEvent.getMessage());
-            if (message.contains(":")) {
+            if (message.contains(": ")) {
                 message = message.split(": ")[1];
+            } else if (message.contains(":")) {
+                message = message.split(":")[1];
             }
             logMessages.add(message);
         }
@@ -154,8 +156,10 @@ public class CacheExpiryAndReloadTestCase {
         List<String> logMessages = new ArrayList<>();
         for (LoggingEvent logEvent : log) {
             String message = String.valueOf(logEvent.getMessage());
-            if (message.contains(":")) {
+            if (message.contains(": ")) {
                 message = message.split(": ")[1];
+            } else if (message.contains(":")) {
+                message = message.split(":")[1];
             }
             logMessages.add(message);
         }
@@ -243,8 +247,10 @@ public class CacheExpiryAndReloadTestCase {
         List<String> logMessages = new ArrayList<>();
         for (LoggingEvent logEvent : log) {
             String message = String.valueOf(logEvent.getMessage());
-            if (message.contains(":")) {
+            if (message.contains(": ")) {
                 message = message.split(": ")[1];
+            } else if (message.contains(":")) {
+                message = message.split(":")[1];
             }
             logMessages.add(message);
         }
@@ -333,8 +339,10 @@ public class CacheExpiryAndReloadTestCase {
         List<String> logMessages = new ArrayList<>();
         for (LoggingEvent logEvent : log) {
             String message = String.valueOf(logEvent.getMessage());
-            if (message.contains(":")) {
+            if (message.contains(": ")) {
                 message = message.split(": ")[1];
+            } else if (message.contains(":")) {
+                message = message.split(":")[1];
             }
             logMessages.add(message);
         }

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/cache/CacheExpiryAndReloadTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/cache/CacheExpiryAndReloadTestCase.java
@@ -66,10 +66,8 @@ public class CacheExpiryAndReloadTestCase {
         List<String> logMessages = new ArrayList<>();
         for (LoggingEvent logEvent : log) {
             String message = String.valueOf(logEvent.getMessage());
-            if (message.contains(": ")) {
-                message = message.split(": ")[1];
-            } else if (message.contains(":")) {
-                message = message.split(":")[1];
+            if (message.contains(":")) {
+                message = message.split(":")[1].trim();
             }
             logMessages.add(message);
         }
@@ -156,10 +154,8 @@ public class CacheExpiryAndReloadTestCase {
         List<String> logMessages = new ArrayList<>();
         for (LoggingEvent logEvent : log) {
             String message = String.valueOf(logEvent.getMessage());
-            if (message.contains(": ")) {
-                message = message.split(": ")[1];
-            } else if (message.contains(":")) {
-                message = message.split(":")[1];
+            if (message.contains(":")) {
+                message = message.split(":")[1].trim();
             }
             logMessages.add(message);
         }
@@ -247,10 +243,8 @@ public class CacheExpiryAndReloadTestCase {
         List<String> logMessages = new ArrayList<>();
         for (LoggingEvent logEvent : log) {
             String message = String.valueOf(logEvent.getMessage());
-            if (message.contains(": ")) {
-                message = message.split(": ")[1];
-            } else if (message.contains(":")) {
-                message = message.split(":")[1];
+            if (message.contains(":")) {
+                message = message.split(":")[1].trim();
             }
             logMessages.add(message);
         }
@@ -339,10 +333,8 @@ public class CacheExpiryAndReloadTestCase {
         List<String> logMessages = new ArrayList<>();
         for (LoggingEvent logEvent : log) {
             String message = String.valueOf(logEvent.getMessage());
-            if (message.contains(": ")) {
-                message = message.split(": ")[1];
-            } else if (message.contains(":")) {
-                message = message.split(":")[1];
+            if (message.contains(":")) {
+                message = message.split(":")[1].trim();
             }
             logMessages.add(message);
         }


### PR DESCRIPTION
## Purpose
> $subject. Fixes the following failures:

```
Identified problems
--
  | testTableJoinQuery1java.lang.ArrayIndexOutOfBoundsException: 1 at io.siddhi.core.query.table.cache.CacheCornerCasesTest.testTableJoinQuery1(CacheCornerCasesTest.java:139)
  | expiryAndReloadTest0java.lang.ArrayIndexOutOfBoundsException: 1 at io.siddhi.core.query.table.cache.CacheExpiryAndReloadTestCase.expiryAndReloadTest0(CacheExpiryAndReloadTestCase.java:70)
  | expiryAndReloadTest1java.lang.ArrayIndexOutOfBoundsException: 1 at io.siddhi.core.query.table.cache.CacheExpiryAndReloadTestCase.expiryAndReloadTest1(CacheExpiryAndReloadTestCase.java:158)
  | expiryAndReloadTest2java.lang.ArrayIndexOutOfBoundsException: 1 at io.siddhi.core.query.table.cache.CacheExpiryAndReloadTestCase.expiryAndReloadTest2(CacheExpiryAndReloadTestCase.java:247)
  | expiryAndReloadTest3java.lang.ArrayIndexOutOfBoundsException: 1 at io.siddhi.core.query.table.cache.CacheExpiryAndReloadTestCase.expiryAndReloadTest3(CacheExpiryAndReloadTestCase.java:337)


```
 
