### PR TITLE
Fix latency tracker markOuts

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/table/Table.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/table/Table.java
@@ -222,6 +222,10 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
         }
         addingEventChunk.reset();
         add(addingEventChunk);
+        if (latencyTrackerInsert != null &&
+                Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+            latencyTrackerInsert.markOut();
+        }
         if (throughputTrackerInsert != null &&
                 Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
             throughputTrackerInsert.eventsIn(noOfEvents);
@@ -336,6 +340,10 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
             latencyTrackerDelete.markIn();
         }
         delete(deletingEventChunk, compiledCondition);
+        if (latencyTrackerDelete != null &&
+                Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+            latencyTrackerDelete.markOut();
+        }
         if (throughputTrackerDelete != null &&
                 Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
             throughputTrackerDelete.eventsIn(noOfEvents);
@@ -415,6 +423,10 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
             latencyTrackerUpdate.markIn();
         }
         update(updatingEventChunk, compiledCondition, compiledUpdateSet);
+        if (latencyTrackerUpdate != null &&
+                Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+            latencyTrackerUpdate.markOut();
+        }
         if (throughputTrackerUpdate != null &&
                 Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
             throughputTrackerUpdate.eventsIn(noOfEvents);
@@ -500,6 +512,10 @@ public abstract class Table implements FindableProcessor, MemoryCalculable {
         }
         updateOrAdd(updateOrAddingEventChunk, compiledCondition, compiledUpdateSet,
                 addingStreamEventExtractor);
+        if (latencyTrackerUpdateOrInsert != null &&
+                Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
+            latencyTrackerUpdateOrInsert.markOut();
+        }
         if (throughputTrackerUpdateOrInsert != null &&
                 Level.BASIC.compareTo(siddhiAppContext.getRootMetricsLevel()) <= 0) {
             throughputTrackerUpdateOrInsert.eventsIn(noOfEvents);


### PR DESCRIPTION
## Purpose
$title. Fixes https://github.com/siddhi-io/siddhi/issues/1771

```
java.lang.IllegalStateException: MarkIn consecutively called without calling markOut in io.siddhi.SiddhiApps.xxx.Siddhi.Tables.xxx.insert.latency
	at io.siddhi.core.util.statistics.metrics.SiddhiLatencyMetric.markIn(SiddhiLatencyMetric.java:55) 
```

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
