### PR TITLE
Fix deadlock on sending data concurrently to pattern query

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/query/input/ProcessStreamReceiver.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/query/input/ProcessStreamReceiver.java
@@ -71,7 +71,7 @@ public class ProcessStreamReceiver implements StreamJunction.Receiver {
         this.siddhiDebugger = siddhiDebugger;
     }
 
-    private void process(ComplexEventChunk<StreamEvent> streamEventChunk) {
+    protected void process(ComplexEventChunk<StreamEvent> streamEventChunk) {
         if (lockWrapper != null) {
             lockWrapper.lock();
         }


### PR DESCRIPTION
## Purpose
Resolves [issue#1790](https://github.com/siddhi-io/siddhi/issues/1790)

## Goals
make `SingleProcessStreamReceiver` always synchronize `patternSyncObject` before locking the `lockWrapper` in `process` method

## Approach
1 Modify `ProcessStreamReceiver#process` to be protected method
2 Overwrite the `process` mothod in `SingleProcessStreamReceiver`,  in the method we synchronize the `patternSyncObject` first then call the `process` method of super class
3 delete synchronization of  `patternSyncObject` in the `processAndClear` method

## Release note
Fix deadlock on sending data concurrently to pattern query

## Documentation
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs


## Test environment
1.8
 
