### PR TITLE
Set source to 1.8 in javadoc plugin configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,7 @@
                     </executions>
                     <configuration>
                         <doclint>none</doclint>
+                        <source>1.8</source>
                         <excludePackageNames>
                             io.siddhi.query.compiler.internal:io.siddhi.query.compiler
                         </excludePackageNames>


### PR DESCRIPTION
## Purpose
> $subject

## Goals
> Avoid the following error during build:
```
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] BUILD FAILURE
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] Total time:  31.376 s
[INFO] [INFO] Finished at: 2022-10-31T21:35:47Z
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:javadoc (docs) on project siddhi-query-api: An error has occurred in Javadoc report generation: 
[INFO] [ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
[INFO] [ERROR] 
[INFO] [ERROR] Command line was: /build/software/java/jdk-11.0.4+11/bin/javadoc @options @packages
[INFO] [ERROR] 
[INFO] [ERROR] Refer to the generated Javadoc files in '/home/jenkins/workspace/siddhi/siddhi/modules/siddhi-query-api/target/site/apidocs' dir.
[INFO] [ERROR] -> [Help 1]
[INFO] [ERROR] 
[INFO] [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[INFO] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
```

## Reference
https://stackoverflow.com/questions/58836862/jdk-11-and-javadoc
 
