### PR TITLE
[4.x.x] Make siddhi application core thread pool size configurable

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/SiddhiConstants.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/SiddhiConstants.java
@@ -126,4 +126,6 @@ public final class SiddhiConstants {
     public static final String AGG_LAST_TIMESTAMP_COL = "AGG_LAST_EVENT_TIMESTAMP";
     public static final String AGG_SHARD_ID_COL = "SHARD_ID";
 
+    public static final int DEFAULT_THREAD_POOL_SIZE = 5;
+
 }

--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/SiddhiAppParser.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/SiddhiAppParser.java
@@ -160,7 +160,9 @@ public class SiddhiAppParser {
                     new ThreadFactoryBuilder().setNameFormat("Siddhi-" + siddhiAppContext.getName() +
                             "-executor-thread-%d").build()));
 
-            siddhiAppContext.setScheduledExecutorService(Executors.newScheduledThreadPool(5,
+            String corePoolSize = siddhiContext.getConfigManager().extractProperty("appThreadPoolSize");
+            siddhiAppContext.setScheduledExecutorService(Executors.newScheduledThreadPool(
+                    (corePoolSize == null) ? SiddhiConstants.DEFAULT_THREAD_POOL_SIZE : Integer.parseInt(corePoolSize),
                     new ThreadFactoryBuilder().setNameFormat("Siddhi-" +
                             siddhiAppContext.getName() + "-scheduler-thread-%d").build()));
 


### PR DESCRIPTION
## Make siddhi app core thread pool size configurable

When number of triggers per a siddhi application exceeds 6, triggers won't reinitialize after db re-connection due to hard corded core pool size of 5. https://github.com/wso2-support/siddhi/blob/8b1ace31c1d645d5a2fc47844a5a55ef6ddd282d/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/parser/SiddhiAppParser.java#L162.

Thus, this PR makes siddhi application core thread pool size configurable.

Here, if the following config is added to the `conf/worker/deployment.yaml` file, the value given in the config as  \<APP_THREAD_POOL_SIZE> would be used as the core pool size. If not, default value of 5 would be used as the core pool size.

```
siddhi:
  properties:
    appThreadPoolSize: <APP_THREAD_POOL_SIZE>
```

e.g:
```
siddhi:
  properties:
    appThreadPoolSize: 10
```

**Issue link:** https://github.com/wso2-enterprise/financial-open-banking/issues/6933

**Doc Issue:** 

**Applicable Labels:** *siddhi-core-4.2.20*

**Related PRs:**

- https://github.com/wso2-support/siddhi/pull/210
- https://github.com/wso2-support/siddhi/pull/211