### PR TITLE
Add support to purge data considering shardId

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiConstants.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/SiddhiConstants.java
@@ -126,6 +126,8 @@ public final class SiddhiConstants {
     public static final String TRANSPORT_CHANNEL_CREATION_IDENTIFIER = "transportChannelCreationEnabled";
 
     public static final String NAMESPACE_PURGE = "purge";
+
+    public static final String PURGE_BY_SHARD_ID_ENABLED = "purgeByShardIdEnabled";
     public static final String NAMESPACE_RETENTION_PERIOD = "retentionPeriod";
 
     public static final String PARTITION_ID_DEFAULT = "null";


### PR DESCRIPTION
## Purpose
Provide support to delete data according to shardId

## Goals
To reduce bottleneck on database if we are to purge all data at once

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

