### PR TITLE
Upgrade log4j version to 2.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -801,7 +801,7 @@
 
         <awaitility.version>4.0.2</awaitility.version>
         <testng.version>7.1.0</testng.version>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.22.1</log4j.version>
         <log4j.imp.pkg.version.range>[2.0, 3.0)</log4j.imp.pkg.version.range>
         <slf4j.version>1.7.35</slf4j.version>
         <mvel2.version>2.4.5.Final</mvel2.version>


### PR DESCRIPTION
## Purpose
Update log4j version to 2.22.1. Many libraries (Spring, etc) have moved onto log4j 2.22.1. This causes conflict and breaks the build when Siddhi library is present. 

The fix is to simply cut a new release of Siddhi with upgraded log4j version. 

## Goals
Update log4j version to 2.22.1, so Siddhi could work with latest version of many other libraries. 