### PR TITLE
Upgrade 3rd party dependencies

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/YAMLConfigManager.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/YAMLConfigManager.java
@@ -62,7 +62,7 @@ public class YAMLConfigManager implements ConfigManager {
 
             Yaml yaml = new Yaml(constructor);
             yaml.setBeanAccess(BeanAccess.FIELD);
-            this.rootConfiguration = yaml.load(yamlContent);
+            this.rootConfiguration = yaml.loadAs(yamlContent, RootConfiguration.class);
         } catch (Exception e) {
             throw new YAMLConfigManagerException("Unable to parse YAML string, '" + yamlContent + "'.", e);
         }

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/YAMLConfigManager.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/config/YAMLConfigManager.java
@@ -26,6 +26,7 @@ import io.siddhi.core.util.config.model.ReferenceChildConfiguration;
 import io.siddhi.core.util.config.model.RootConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
 import org.yaml.snakeyaml.introspector.BeanAccess;
@@ -53,8 +54,8 @@ public class YAMLConfigManager implements ConfigManager {
      */
     private void init(String yamlContent) throws YAMLConfigManagerException {
         try {
-            CustomClassLoaderConstructor constructor = new CustomClassLoaderConstructor(
-                    RootConfiguration.class, RootConfiguration.class.getClassLoader());
+            CustomClassLoaderConstructor constructor =
+                    new CustomClassLoaderConstructor(RootConfiguration.class.getClassLoader(), new LoaderOptions());
             PropertyUtils propertyUtils = new PropertyUtils();
             propertyUtils.setSkipMissingProperties(true);
             constructor.setPropertyUtils(propertyUtils);

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/stream/FaultStreamTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/stream/FaultStreamTestCase.java
@@ -513,7 +513,7 @@ public class FaultStreamTestCase {
                 "@OnError(action='stream')" +
                 "define stream cseEventStream (symbol string, price float, volume long);" +
                 "\n" +
-                "@sink(type='inMemory', topic='{{symbol}}', on.error='stream', @map(type='passThrough')) " +
+                "@sink(type='inMemory', topic='sample', on.error='stream', @map(type='passThrough')) " +
                 "define stream outputStream (symbol string, price float, sym1 string);" +
                 "\n" +
                 "@info(name = 'query1') " +
@@ -548,7 +548,7 @@ public class FaultStreamTestCase {
             Thread.sleep(500);
             AssertJUnit.assertTrue(((UnitTestAppender) logger.getAppenders().
                     get("UnitTestAppender")).getMessages().contains("after consuming events from Stream " +
-                    "'outputStream', Subscriber for topic 'IBM' is unavailable. Hence, dropping event"));
+                    "'outputStream', Subscriber for topic 'sample' is unavailable. Hence, dropping event"));
         } catch (Exception e) {
             Assert.fail("Unexpected exception occurred when testing.", e);
         } finally {

--- a/modules/siddhi-feature/pom.xml
+++ b/modules/siddhi-feature/pom.xml
@@ -200,7 +200,7 @@
                                     <version>${slf4j.version}</version>
                                 </bundle>
                                 <bundle>
-                                    <symbolicName>org.apache.logging.log4j.slf4j-impl</symbolicName>
+                                    <symbolicName>org.apache.logging.log4j.slf4j.impl</symbolicName>
                                     <version>${log4j.version}</version>
                                 </bundle>
                                 <bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -796,20 +796,20 @@
     <properties>
         <!-- version ranges-->
         <com.lmax.disruptor.version.range>[3.0.0, 4.0.0)</com.lmax.disruptor.version.range>
-        <google.guava.version.range>[23.0.0, 32.0.0)</google.guava.version.range>
+        <google.guava.version.range>[23.0.0, 34.0.0)</google.guava.version.range>
         <org.quartz.version.range>[2.0.0, 3.0.0)</org.quartz.version.range>
 
         <awaitility.version>4.0.2</awaitility.version>
         <testng.version>7.1.0</testng.version>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.22.1</log4j.version>
         <log4j.imp.pkg.version.range>[2.0, 3.0)</log4j.imp.pkg.version.range>
-        <slf4j.version>1.7.35</slf4j.version>
+        <slf4j.version>2.0.11</slf4j.version>
         <mvel2.version>2.4.5.Final</mvel2.version>
         <antlr.runtime.version>4.11.1</antlr.runtime.version>
         <disruptor.version>3.4.2.wso2v1</disruptor.version>
-        <guava.version>31.1-jre</guava.version>
-        <guava.bundle.version>31.1.0.jre</guava.bundle.version>
-        <gson.version>2.9.1</gson.version>
+        <guava.version>33.0.0-jre</guava.version>
+        <guava.bundle.version>33.0.0.jre</guava.bundle.version>
+        <gson.version>2.10.1</gson.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <classindex.version>3.9</classindex.version>
         <quartz.version>2.3.2</quartz.version>
@@ -824,7 +824,7 @@
         <msf4j.version>2.8.1</msf4j.version>
         <maven.shadeplugin.version>3.2.1</maven.shadeplugin.version>
         <servlet-api-version>2.5</servlet-api-version>
-        <jackson-datatype-joda-version>2.13.1</jackson-datatype-joda-version>
+        <jackson-datatype-joda-version>2.16.0</jackson-datatype-joda-version>
         <maven.core.version>3.6.3</maven.core.version>
         <maven.plugin.api.version>3.6.3</maven.plugin.api.version>
         <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -829,8 +829,8 @@
         <maven.plugin.api.version>3.6.3</maven.plugin.api.version>
         <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>
         <freemarker.version>2.3.29</freemarker.version>
-        <commons.io.version>1.3.2</commons.io.version>
-        <snakeyaml.version>1.30</snakeyaml.version>
+        <commons.io.version>2.15.1</commons.io.version>
+        <snakeyaml.version>2.2</snakeyaml.version>
         <org.jacoco.version>0.8.5</org.jacoco.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
         <mavan.checkstyle.suppression.file>checkstyle-suppressions.xml</mavan.checkstyle.suppression.file>


### PR DESCRIPTION
## Purpose
This PR will update the following 3rd party dependencies.
- guava - 33.0.0
- slf4j - 2.0.11
- gson - 2.10.1
- jackson-datatype-joda - 2.16.0
- commons.io - 2.15.1
- snakeyaml -2.2

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 
