### PR TITLE
Close BufferedReader in SiddhiExtensionLoader

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/SiddhiExtensionLoader.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/util/SiddhiExtensionLoader.java
@@ -162,6 +162,7 @@ public class SiddhiExtensionLoader {
                 while ((extensionDetails = br.readLine()) != null) {
                     resources.add(namespace + ":" + extensionDetails);
                 }
+                br.close();
             } finally {
                 inputStream.close();
             }


### PR DESCRIPTION
## Purpose
$subject

Unable to use try with resources block as the default java version specified is Java 6[1] which does not support try with resources.

[1] https://github.com/siddhi-io/siddhi/blob/3.2.x/pom.xml#L315