### PR TITLE
Fix issue 1842

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/event/stream/holder/SnapshotableStreamEventQueue.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/event/stream/holder/SnapshotableStreamEventQueue.java
@@ -99,6 +99,9 @@ public class SnapshotableStreamEventQueue implements Iterator<StreamEvent>, Seri
         }
         if (previousToLastReturned != null) {
             previousToLastReturned.setNext(lastReturned.getNext());
+            if (lastReturned.getNext() == null) {
+                last = previousToLastReturned;
+            }
         } else {
             first = lastReturned.getNext();
             if (first == null) {

--- a/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/DeleteFromTableTestCase.java
+++ b/modules/siddhi-core/src/test/java/io/siddhi/core/query/table/DeleteFromTableTestCase.java
@@ -334,5 +334,62 @@ public class DeleteFromTableTestCase {
 
     }
 
+    @Test
+    public void deleteFromTableTest6() throws InterruptedException {
+        log.info("deleteFromTableTest6");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String streams = "" +
+                "define stream StockStream (symbol string, price float, vol long); " +
+                "define stream DeleteStockStream (symbol string, price float, vol long); " +
+                "define stream CountStockStream (symbol string); " +
+                "define table StockTable (symbol string, price float, volume long); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream " +
+                "select symbol, price, vol as volume " +
+                "insert into StockTable ;" +
+                "" +
+                "@info(name = 'query2') " +
+                "from DeleteStockStream[vol>=100] " +
+                "delete StockTable " +
+                "   on StockTable.symbol==symbol ;" +
+                "" +
+                "@info(name = 'query3') " +
+                "from CountStockStream#window.length(0) join StockTable" +
+                " on CountStockStream.symbol==StockTable.symbol " +
+                "select CountStockStream.symbol as symbol " +
+                "insert into CountResultsStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        InputHandler deleteStockStream = siddhiAppRuntime.getInputHandler("DeleteStockStream");
+        InputHandler countStockStream = siddhiAppRuntime.getInputHandler("CountStockStream");
+
+        siddhiAppRuntime.addCallback("CountResultsStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                inEventCount += events.length;
+            }
+        });
+        siddhiAppRuntime.start();
+
+        stockStream.send(new Object[]{"WSO2", 55.6f, 100L});
+        stockStream.send(new Object[]{"IBM", 75.6f, 100L});
+        // Remove last event in the StockTable
+        deleteStockStream.send(new Object[]{"IBM", 57.6f, 100L});
+
+        stockStream.send(new Object[]{"WSO2", 57.6f, 100L});
+        countStockStream.send(new Object[]{"WSO2"});
+
+        Thread.sleep(500);
+        AssertJUnit.assertEquals(2, inEventCount);
+        siddhiAppRuntime.shutdown();
+
+    }
+
 
 }


### PR DESCRIPTION
## Purpose
> Resolves issue [1842 ](https://github.com/siddhi-io/siddhi/issues/1842)- Improper threads synchronization in the ThreadBarrier leading to snapshot failures

## Goals
> Updated ThreadBarrier class to ensure that activeThreads counter is not incremented when threadBarrier.enter() is called in the same thread for which the counter has already been incremented.

## Approach
Used ThreadLocal to maintain the counter of enter operations within the same thread. Added inline class MutableInteger as it's 6x faster than use of get()->set() methods.

> ThreadLocalBenchmark.testAtomicInteger     ss    2   838.083          us/op
> ThreadLocalBenchmark.testGetAndSet           ss    2  3431.792          us/op
> ThreadLocalBenchmark.testMutableInteger    ss    2   558.584          us/op