### PR TITLE
Fix of the issue when removal of the last event in the InMemory table…

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/event/stream/holder/SnapshotableStreamEventQueue.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/event/stream/holder/SnapshotableStreamEventQueue.java
@@ -99,6 +99,9 @@ public class SnapshotableStreamEventQueue implements Iterator<StreamEvent>, Seri
         }
         if (previousToLastReturned != null) {
             previousToLastReturned.setNext(lastReturned.getNext());
+            if (lastReturned.getNext() == null) {
+                last = previousToLastReturned;
+            }
         } else {
             first = lastReturned.getNext();
             if (first == null) {


### PR DESCRIPTION
## Purpose
Resolves issue [1822](https://github.com/siddhi-io/siddhi/issues/1822) - Removal of the last stored event in the InMemory table disrupts the references chain, subsequently causing improper behaviour within the InMemory table. Any future inserts are erroneously appended to the removed event, leading to unexpected and undesired outcomes.

## Goals
Fix the logic of the remove method in the SnapshotableStreamEventQueue class to gracefully handle the removal of the last item. Reset the `last` variable to point to the previous item if the item being removed is the last one.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

