### PR TITLE
Clear expired throttle policy trackers when throttle policy is redeployed

### DIFF
--- a/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/selector/attribute/processor/executor/GroupByAggregationAttributeExecutor.java
+++ b/modules/siddhi-core/src/main/java/org/wso2/siddhi/core/query/selector/attribute/processor/executor/GroupByAggregationAttributeExecutor.java
@@ -58,6 +58,7 @@ public class GroupByAggregationAttributeExecutor extends AbstractAggregationAttr
                     expiredTrackers = new ArrayList<ExpiredAggregatorTracker>();
                     allExpiredTrackers.put(executionPlanContext.getName(), expiredTrackers);
                 }
+                expiredTrackers.clear();
                 expiredTrackers.add(expiredAggregatorTracker);
 
                 if (aggregatorCleanTimer == null) {


### PR DESCRIPTION
### Purpose
> Memory is growing continuously in Control Plane node each time when redeploying a throttling policy leading to high CPU and memory usage and OOM scenarios.
Related Issue : https://github.com/wso2/api-manager/issues/3815

### Goals
> Stop memory growth when redeploying a throttling policy.

### Implementation
> Clear the old throttle policy trackers when throttle policy is redeployed. 