### PR TITLE
Bump snakeyaml, commons-lang3, and jackson-datatype-joda

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -845,7 +845,7 @@
         <guava.version>33.0.0-jre</guava.version>
         <guava.bundle.version>33.0.0.jre</guava.bundle.version>
         <gson.version>2.10.1</gson.version>
-        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
         <classindex.version>3.9</classindex.version>
         <quartz.version>2.3.2</quartz.version>
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
@@ -859,7 +859,7 @@
         <msf4j.version>2.8.1</msf4j.version>
         <maven.shadeplugin.version>3.2.1</maven.shadeplugin.version>
         <servlet-api-version>2.5</servlet-api-version>
-        <jackson-datatype-joda-version>2.18.6</jackson-datatype-joda-version>
+        <jackson-datatype-joda-version>2.21.2</jackson-datatype-joda-version>
         <maven.core.version>3.8.8</maven.core.version>
         <maven.plugin.api.version>3.6.3</maven.plugin.api.version>
         <maven.shared.utils.version>3.4.2</maven.shared.utils.version>
@@ -870,7 +870,7 @@
         <freemarker.version>2.3.29</freemarker.version>
         <commons.io.version>2.15.1</commons.io.version>
         <json.smart.version>2.5.2</json.smart.version>
-        <snakeyaml.version>2.2</snakeyaml.version>
+        <snakeyaml.version>2.6</snakeyaml.version>
         <org.jacoco.version>0.8.5</org.jacoco.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
         <mavan.checkstyle.suppression.file>checkstyle-suppressions.xml</mavan.checkstyle.suppression.file>


### PR DESCRIPTION
## Summary

- **snakeyaml**: 2.2 → 2.6 (latest; CVE-free in 2.4+)
- **commons-lang3**: 3.17.0 → 3.20.0 (latest; CVE-2025-48924 fixed in 3.18.0)
- **jackson-datatype-joda**: 2.18.6 → 2.21.2 (aligns with latest jackson 2.21.x line)

All changes are version property updates in the root `pom.xml`; module poms inherit via `${...}` properties.

## Test plan

- [x] `mvn clean install -DskipTests` passes with all 13 modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)